### PR TITLE
Github action added for compiling ww130_cli app

### DIFF
--- a/.github/workflows/check-ww130_cli-app.yml
+++ b/.github/workflows/check-ww130_cli-app.yml
@@ -1,65 +1,75 @@
-name: Build and Test Functions on WW130_cli
+name: Build and Test WW130_cli
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
-# Make and build the WW130_cli application
+env:
+  ARM_TOOLCHAIN_VERSION: 13.3.rel1
+  ARM_TOOLCHAIN_URL: https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # - name: Set up build dependencies
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get install -y arm-none-eabi-gcc
+      - name: Cache ARM toolchain
+        uses: actions/cache@v3
+        id: cache-arm-toolchain
+        with:
+          path: /usr/local/arm-gnu-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi
+          key: ${{ runner.os }}-arm-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}
 
-    - name: Set up build dependencies
-      run: |
-        wget -q https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
-        tar -xf arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
-        sudo cp -r arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi /usr/local/
-        echo "/usr/local/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/bin" >> $GITHUB_PATH
+      - name: Set up build dependencies
+        if: steps.cache-arm-toolchain.outputs.cache-hit != 'true'
+        run: |
+          wget -q ${{ env.ARM_TOOLCHAIN_URL }}
+          tar -xf arm-gnu-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi.tar.xz
+          sudo mv arm-gnu-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi /usr/local/
 
-    - name: Update APP_TYPE variable to ww130_cli
-      run: |
-            sed -i 's/APP_TYPE = .*/APP_TYPE = ww130_cli/' EPII_CM55M_APP_S/app/ww_projects/ww.mk
+      - name: Add ARM toolchain to PATH
+        run: echo "/usr/local/arm-gnu-toolchain-${{ env.ARM_TOOLCHAIN_VERSION }}-x86_64-arm-none-eabi/bin" >> $GITHUB_PATH
 
-    - name: Build WW130_cli
-      run: |
-        cd EPII_CM55M_APP_S/
-        make clean
-        make
+      - name: Update APP_TYPE variable
+        run: |
+          sed -i 's/APP_TYPE = .*/APP_TYPE = ww130_cli/' EPII_CM55M_APP_S/app/ww_projects/ww.mk
 
-# Test specific functionality within the WW130_cli application
-#   test:
-#     needs: build
-#     runs-on: ubuntu-latest
+      - name: Build WW130_cli
+        run: |
+          cd EPII_CM55M_APP_S/
+          make clean
+          make
 
-#     steps:
-#     - name: Checkout repository
-#       uses: actions/checkout@v4
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: WW130_cli-build
+          path: EPII_CM55M_APP_S/build/
 
-#     - name: Initialize fatfs
-#       run: |
-#         # Add command to initialize fatfs here
-#         ./path/to/WW130_cli initialize_fatfs
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-#     - name: Initialize Camera
-#       run: |
-#         # Add command to initialize the camera here
-#         ./path/to/WW130_cli initialize_camera
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: WW130_cli-build
+          path: EPII_CM55M_APP_S/build/
 
-#     - name: Run Example Capture
-#       run: |
-#         # Add command to run an example capture here
-#         ./path/to/WW130_cli example_capture
+      - name: Run tests
+        run: |
+          # Add your test commands here
+          # Example:
+          # ./EPII_CM55M_APP_S/build/WW130_cli initialize_fatfs
+          # ./EPII_CM55M_APP_S/build/WW130_cli initialize_camera
+          # ./EPII_CM55M_APP_S/build/WW130_cli example_capture
+          echo "Running tests..."
+          # Replace this with actual test commands

--- a/.github/workflows/check-ww130_cli-app.yml
+++ b/.github/workflows/check-ww130_cli-app.yml
@@ -1,0 +1,65 @@
+name: Build and Test Functions on WW130_cli
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Make and build the WW130_cli application
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    # - name: Set up build dependencies
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get install -y arm-none-eabi-gcc
+
+    - name: Set up build dependencies
+      run: |
+        wget -q https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
+        tar -xf arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi.tar.xz
+        sudo cp -r arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi /usr/local/
+        echo "/usr/local/arm-gnu-toolchain-13.3.rel1-x86_64-arm-none-eabi/bin" >> $GITHUB_PATH
+
+    - name: Update APP_TYPE variable to ww130_cli
+      run: |
+            sed -i 's/APP_TYPE = .*/APP_TYPE = ww130_cli/' EPII_CM55M_APP_S/app/ww_projects/ww.mk
+
+    - name: Build WW130_cli
+      run: |
+        cd EPII_CM55M_APP_S/
+        make clean
+        make
+
+# Test specific functionality within the WW130_cli application
+#   test:
+#     needs: build
+#     runs-on: ubuntu-latest
+
+#     steps:
+#     - name: Checkout repository
+#       uses: actions/checkout@v4
+
+#     - name: Initialize fatfs
+#       run: |
+#         # Add command to initialize fatfs here
+#         ./path/to/WW130_cli initialize_fatfs
+
+#     - name: Initialize Camera
+#       run: |
+#         # Add command to initialize the camera here
+#         ./path/to/WW130_cli initialize_camera
+
+#     - name: Run Example Capture
+#       run: |
+#         # Add command to run an example capture here
+#         ./path/to/WW130_cli example_capture


### PR DESCRIPTION
Initial Github Action added to "make clean" and "make" the WW130_cli app.

I've currently got the GCC compiler downloading version 13.3 to build the code correctly.
When I ran the commented-out code (line 21-24), it was only running version 10.2 and had runtime errors.

Skeleton code included to initialise specific device functions. 
TODO, update that code to execute said functions. 