### PR TITLE
fix(ci): bump Node.js 20 to 22 for native WebSocket support

### DIFF
--- a/.github/workflows/upload_firmware.yml
+++ b/.github/workflows/upload_firmware.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install Node Dependencies
         run: npm install @supabase/supabase-js


### PR DESCRIPTION
Latest @supabase/supabase-js realtime client requires native WebSocket, available in Node.js 22+. Fixes CI failure in upload-to-supabase job.