### PR TITLE
Feat/ble fast transfer

### DIFF
--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/camera_switch.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/camera_switch.c
@@ -128,17 +128,31 @@ bool cameraSwitch_autoSwitchCheck(void) {
  */
 void cameraSwitch_labelBootSlot(void) {
 	int activeSlot;
+	int result;
 	uint8_t variant;
 
 	variant = cameraSwitch_thisVariant();
 	if (variant == XIP_SLOT_VARIANT_UNKNOWN) {
-		return;
+		return;		// build variant does not participate in camera switching
 	}
 
+	// Failures below are LOUD and retried once: a missed label strands the
+	// app's camera switching on 'unknown' until this image happens to boot
+	// again. Seen once in the field: the label write was silently lost during
+	// the brief mid-update boot of a dual-image firmware update.
 	activeSlot = xip_get_active_slot();
 	if (activeSlot < 0) {
+		xprintf("labelBootSlot: cannot read active slot - variant label NOT written\n");
 		return;
 	}
 
-	xip_set_slot_variant((uint8_t) activeSlot, variant);
+	result = xip_set_slot_variant((uint8_t) activeSlot, variant);
+	if (result != 0) {
+		xprintf("labelBootSlot: slot %c label write failed (%d) - retrying once\n",
+				(activeSlot == 0) ? 'A' : 'B', result);
+		result = xip_set_slot_variant((uint8_t) activeSlot, variant);
+		if (result != 0) {
+			xprintf("labelBootSlot: retry failed (%d) - camera switching will see 'unknown'\n", result);
+		}
+	}
 }

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -141,6 +141,9 @@ extern GPS_Coordinate exif_gps_deviceLon;
 extern GPS_Altitude exif_gps_deviceAlt;
 
 extern directoryManager_t dirManager;
+// Defined in if_task.c: true while a file-receive session is active. Suppresses the
+// high-volume per-packet console logging that throttles the transfer at 921600 baud.
+extern volatile bool g_fileRxActive;
 extern QueueHandle_t xIfTaskQueue;
 extern QueueHandle_t xImageTaskQueue;
 
@@ -760,6 +763,12 @@ static APP_MSG_DEST_T handleEventForIdle(APP_MSG_T rxMessage) {
 		}
 
 		if (res == FR_OK) {
+			// FA_CREATE_ALWAYS truncated any existing file, freeing its cluster
+			// chain. Commit that (and let the card finish the internal
+			// housekeeping) BEFORE the first data write - otherwise re-sending a
+			// large file failed on packet 1 with FR_DISK_ERR (ftx err 7) because
+			// the card was still busy from freeing ~1000 clusters.
+			f_sync(&transferFile);
 			transferFileOpen = true;
 			transferWritesSinceSync = 0;
 			xprintf("Opened '%s' for writing\n", fileOp->fileName);
@@ -786,10 +795,21 @@ static APP_MSG_DEST_T handleEventForIdle(APP_MSG_T rxMessage) {
 			res = FR_INVALID_OBJECT;
 		}
 		else {
-			res = f_write(&transferFile, fileOp->buffer, fileOp->length, &bw);
-			if (res == FR_OK && bw != fileOp->length) {
-				xprintf("Short write: %u of %lu bytes\n", bw, fileOp->length);
-				res = FR_DISK_ERR;
+			// Retry transient SD write failures: the card can be briefly busy
+			// (internal garbage collection, or recovering after a large-file
+			// truncate), which returns FR_DISK_ERR. A short delay lets it
+			// recover; only a persistent failure becomes ftx err 7.
+			for (int attempt = 0; ; attempt++) {
+				res = f_write(&transferFile, fileOp->buffer, fileOp->length, &bw);
+				if (res == FR_OK && bw != fileOp->length) {
+					xprintf("Short write: %u of %lu bytes\n", bw, fileOp->length);
+					res = FR_DISK_ERR;
+				}
+				if (res == FR_OK || attempt >= 3) {
+					break;
+				}
+				xprintf("SD write err %d, retry %d/3\n", res, attempt + 1);
+				vTaskDelay(pdMS_TO_TICKS(15));
 			}
 
 			// Periodic metadata flush — see TRANSFER_WRITES_PER_SYNC above.
@@ -1632,10 +1652,12 @@ static void vFatFsTask(void *pvParameters) {
 				eventString = "Unexpected";
 			}
 
-			XP_LT_CYAN
-			xprintf("\nFatFS Task ");
-			XP_WHITE;
-			xprintf("received event '%s' (0x%04x). Rx data = 0x%08x\r\n", eventString, event, rxData);
+			if (!g_fileRxActive) {
+				XP_LT_CYAN
+				xprintf("\nFatFS Task ");
+				XP_WHITE;
+				xprintf("received event '%s' (0x%04x). Rx data = 0x%08x\r\n", eventString, event, rxData);
+			}
 
 			old_state = fatFs_task_state;
 
@@ -1660,7 +1682,7 @@ static void vFatFsTask(void *pvParameters) {
 				break;
 			}
 
-			if (old_state != fatFs_task_state) {
+			if ((old_state != fatFs_task_state) && !g_fileRxActive) {
 				// state has changed
 				XP_LT_CYAN;
 				xprintf("FatFS Task state changed ");
@@ -1677,7 +1699,7 @@ static void vFatFsTask(void *pvParameters) {
 
 				if (xQueueSend(targetQueue, (void *)&sendMsg, __QueueSendTicksToWait) != pdTRUE) {
 					xprintf("FatFS task sending event 0x%x failed\r\n", sendMsg.msg_event);
-				} else {
+				} else if (!g_fileRxActive) {
 					xprintf("FatFS task sending event 0x%04x. Tx data = 0x%08x\r\n", sendMsg.msg_event, sendMsg.msg_data);
 				}
 			}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -802,8 +802,13 @@ static APP_MSG_DEST_T handleEventForIdle(APP_MSG_T rxMessage) {
 			for (int attempt = 0; ; attempt++) {
 				res = f_write(&transferFile, fileOp->buffer, fileOp->length, &bw);
 				if (res == FR_OK && bw != fileOp->length) {
-					xprintf("Short write: %u of %lu bytes\n", bw, fileOp->length);
+					// FR_OK with a short count means the volume is full. Do NOT
+					// retry: the file pointer has already advanced by bw, so a
+					// rewrite of the full buffer would duplicate those bytes and
+					// corrupt the file. Report it as a write error (ftx err 7).
+					xprintf("Short write: %u of %lu bytes (volume full?)\n", bw, fileOp->length);
 					res = FR_DISK_ERR;
+					break;
 				}
 				if (res == FR_OK || attempt >= 3) {
 					break;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -170,6 +170,15 @@ static bool mounted;
 static FIL transferFile;
 static bool transferFileOpen = false;
 
+// Flush FAT metadata with f_sync() every N appends. Without this a long
+// transfer accumulates unbounded dirty filesystem state (cluster chain and
+// directory updates), which is the suspected cause of the non-deterministic
+// f_write() failures ("ftx err 7") seen on transfers beyond ~3-7KB.
+// 16 x 241-byte chunks ≈ 3.9KB between syncs; each f_sync costs ~50-100ms,
+// amortised to a few ms per packet.
+#define TRANSFER_WRITES_PER_SYNC 16
+static uint16_t transferWritesSinceSync = 0;
+
 static TickType_t xStartTime;
 static TickType_t accumulatedTime;
 
@@ -752,6 +761,7 @@ static APP_MSG_DEST_T handleEventForIdle(APP_MSG_T rxMessage) {
 
 		if (res == FR_OK) {
 			transferFileOpen = true;
+			transferWritesSinceSync = 0;
 			xprintf("Opened '%s' for writing\n", fileOp->fileName);
 		}
 		else {
@@ -780,6 +790,16 @@ static APP_MSG_DEST_T handleEventForIdle(APP_MSG_T rxMessage) {
 			if (res == FR_OK && bw != fileOp->length) {
 				xprintf("Short write: %u of %lu bytes\n", bw, fileOp->length);
 				res = FR_DISK_ERR;
+			}
+
+			// Periodic metadata flush — see TRANSFER_WRITES_PER_SYNC above.
+			// A failed sync is reported like a failed write (ftx err 7).
+			if (res == FR_OK && ++transferWritesSinceSync >= TRANSFER_WRITES_PER_SYNC) {
+				res = f_sync(&transferFile);
+				transferWritesSinceSync = 0;
+				if (res != FR_OK) {
+					xprintf("f_sync failed (err %d)\n", res);
+				}
 			}
 		}
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fileRx.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fileRx.c
@@ -20,6 +20,10 @@
 #include "crc16_ccitt.h"
 #include "printf_x.h"
 
+// Defined in if_task.c: true while a file-receive session is active. Used to
+// suppress the high-volume per-packet console logging that throttles the transfer.
+extern volatile bool g_fileRxActive;
+
 /*********************************************** Local Defines ***********************************************/
 
 #define FILERX_MAX_FILENAME     12      // 8.3: up to 8 base + '.' + up to 3 ext (= IMAGEFILENAMELEN - 1)
@@ -176,9 +180,12 @@ fileRx_result_t fileRx_data(const uint8_t *chunk, uint16_t len, uint8_t packetNu
     session.bytesReceived += len;
     session.lastPacketNum  = packetNum;
 
-    XP_LT_BLUE;	// colour for File TX operations
-    xprintf("FileTX: Received packet %d (%d bytes)\n", packetNum, len);
-    XP_WHITE;
+    // Per-packet log suppressed during an active transfer (throttles at 921600 baud).
+    if (!g_fileRxActive) {
+        XP_LT_BLUE;	// colour for File TX operations
+        xprintf("FileTX: Received packet %d (%d bytes)\n", packetNum, len);
+        XP_WHITE;
+    }
 
     return FILERX_OK;
 }

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fileRx.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fileRx.h
@@ -24,7 +24,9 @@
 
 /*********************************************** Global Defines ***********************************************/
 
-#define FILERX_MAX_FILE_SIZE    (1024u * 1024u)     // 1 MB ceiling on received file size
+// Ceiling on received file size. Must cover edge AI models (1-5 MB) as well
+// as firmware images (~0.5 MB); matches the app's MAX_TRANSFER_SIZE_BYTES.
+#define FILERX_MAX_FILE_SIZE    (10u * 1024u * 1024u)
 
 /*********************************************** Global Type Declarations ************************************/
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
@@ -64,11 +64,20 @@
 // This timer timed out, and the ML62BA saw two interprocessor interrupts and gave a 'busy' error.
 // See if this is resolved by increasing the timeout
 //#define MISSINGMASTERTIME	300
-#define MISSINGMASTERTIME	1000
+// Raised from 1000ms: while streaming a file, Android periodically re-requests
+// CONNECTION_PRIORITY_HIGH to stop the interval decaying (measured: it drops from
+// ~15ms to ~200ms ~24s in, collapsing throughput from ~8KB/s to ~1.3KB/s). Each
+// re-request renegotiates the link and stalls it ~950ms — right at the old 1000ms
+// timeout, so the HX declared "master did not read" and aborted the transfer. A
+// 4000ms window rides through the renegotiation while staying under the 5s file
+// session inactivity and the app's 15s silence timeout.
+#define MISSINGMASTERTIME	4000
 
 #define DBG_EVT_IICS_CMD_LOG 1
 #if DBG_EVT_IICS_CMD_LOG
-    #define dbg_evt_iics_cmd(fmt, ...)   xprintf(fmt, ##__VA_ARGS__)
+    // Suppressed during an active file-receive session (g_fileRxActive) — the
+    // per-packet I2C trace is high-volume and throttles the transfer at 921600 baud.
+    #define dbg_evt_iics_cmd(fmt, ...)   do { if (!g_fileRxActive) xprintf(fmt, ##__VA_ARGS__); } while (0)
 #else
     #define dbg_evt_iics_cmd(fmt, ...)
 #endif
@@ -255,6 +264,14 @@ bool lastMessageSent = false;
 
 bool sendWakeMsg = false;
 
+// True while a file-receive session is active (FILE_START..close). The per-packet
+// console logging (hex dumps, state changes, event traces, ACK sends) is very high
+// volume at 921600 baud and measurably throttles the transfer loop, so it is
+// suppressed while this is set. Cleared at every session end (restoreInactivityPeriod)
+// and — belt-and-braces — reset to false on the DPD reboot that follows an abandoned
+// transfer, so it can never stay stuck. Read from ISR/callback context too, so volatile.
+volatile bool g_fileRxActive = false;
+
 // Measure interval between events
 static TickType_t fileRxStartTime;
 
@@ -271,6 +288,8 @@ static void restoreInactivityPeriod(void) {
 		inactivity_setPeriod(savedInactivityPeriod);
 		inactivityExtended = false;
 	}
+	// Session over — re-enable the verbose per-packet console logging.
+	g_fileRxActive = false;
 }
 
 /**
@@ -289,6 +308,18 @@ static void i2csTxDoneEvent(void *param) {
 	if (xTimerStop(timerHndlMissingMaster, 0) != pdPASS) {
 		configASSERT(0);	// TODO add debug messages?
 	}
+
+	// Re-arm the slave receiver HERE, the instant the master finishes reading our
+	// ACK — not later in i2cTransmissionComplete() (which runs only after this
+	// event is dequeued by the ifTask). During a sliding-window file transfer the
+	// master (nRF) writes the next packet immediately after reading each ACK; the
+	// task-scheduling gap left the slave deaf, so the first bytes (the frame
+	// header + packet number) were lost. The malformed frame then failed CRC and
+	// was silently dropped, no ACK was sent, and the transfer stalled until the
+	// master's 10s "AI processor not responding" timeout. Arming in this callback
+	// closes that window. (Re-arm is removed from i2cTransmissionComplete() so a
+	// packet received in the meantime is not clobbered by a second enable_read.)
+	hx_lib_i2ccomm_enable_read(iic_id, (unsigned char *) gRead_buf, WW130_MAX_RBUF_SIZE);
 
 	//send_msg.msg_data = iic_info_ptr->slv_addr;
 	send_msg.msg_data = 0;
@@ -379,9 +410,11 @@ static void i2cTransmissionComplete(void) {
 	// further commands (including transfer of multiple chunks of JPEG file data).
 	xSemaphoreGive(xI2CTxSemaphore);
 
-    // Prepare for the next incoming message
-    clear_read_buf_header();
-    hx_lib_i2ccomm_enable_read(iic_id, (unsigned char *) gRead_buf, WW130_MAX_RBUF_SIZE);
+    // NOTE: the slave receiver is now re-armed in the i2csTxDoneEvent() callback the
+    // moment the master finishes reading our ACK, closing the task-scheduling window
+    // that was dropping the header of the next back-to-back packet during fast
+    // sliding-window transfers. Do NOT enable_read again here — a packet may already
+    // have been received into gRead_buf, and a second enable_read would discard it.
 }
 
 /**
@@ -411,7 +444,10 @@ static void i2cRxDataReady(void) {
 
 	XP_LT_GREY;
 	// Let's print the message: 4 bytes header, payload, 2 bytes CRC
-	printf_x_printBuffer(gRead_buf, (I2CCOMM_HEADER_SIZE + length + I2CCOMM_CHECKSUM_SIZE ));
+	// (suppressed during a file transfer — this hex dump is ~16 lines per packet)
+	if (!g_fileRxActive) {
+		printf_x_printBuffer(gRead_buf, (I2CCOMM_HEADER_SIZE + length + I2CCOMM_CHECKSUM_SIZE ));
+	}
 	XP_WHITE;
 
 	crcOK = crc16_ccitt_validate(gRead_buf, I2CCOMM_HEADER_SIZE + length + I2CCOMM_CHECKSUM_SIZE );
@@ -496,6 +532,11 @@ static void i2cRxDataReady(void) {
 				inactivity_setPeriod(FILERX_SESSION_INACTIVITY_MS);
 			}
 		}
+
+		// Suppress the high-volume per-packet console logging for the duration of
+		// the transfer (restored in restoreInactivityPeriod()). At 921600 baud the
+		// hex dumps + state/event traces measurably throttle the packet loop.
+		g_fileRxActive = true;
 
 		fileRxOp.fileName      = (char *)fileRx_getFileName();
 		fileRxOp.buffer        = NULL;
@@ -724,9 +765,11 @@ static void i2ccomm_write_enable(uint8_t * message, aiProcessor_msg_type_t messa
     // This is a wrapper around SCB_CleanDCache_by_Addr() - ensures that any data in the D-cache is committed to RAM
     hx_CleanDCache_by_Addr((void *) gWrite_buf, I2CCOMM_MAX_RBUF_SIZE);
 
-    // for debugging, print the buffer
+    // for debugging, print the buffer (suppressed during a file transfer)
     XP_LT_GREY;
-    printf_x_printBuffer((uint8_t *) gWrite_buf, I2CCOMM_HEADER_SIZE + length + I2CCOMM_CHECKSUM_SIZE);
+    if (!g_fileRxActive) {
+        printf_x_printBuffer((uint8_t *) gWrite_buf, I2CCOMM_HEADER_SIZE + length + I2CCOMM_CHECKSUM_SIZE);
+    }
     XP_WHITE;
 
     // non-blocking I2C transmit. Expect an interrupt in i2cs_cb_tx() soon.
@@ -1254,9 +1297,11 @@ static APP_MSG_DEST_T  handleEventForStateDiskOp(APP_MSG_T rxMessage) {
 
 		// How long did it take?
 		elapsedTime = app_getElapsedMs(fileRxStartTime);
-	    XP_LT_BLUE;	// colour for File TX operations
-	    xprintf("   FileTX: disk operation took %dms\n", elapsedTime);
-	    XP_WHITE;
+	    if (!g_fileRxActive) {
+	        XP_LT_BLUE;	// colour for File TX operations
+	        xprintf("   FileTX: disk operation took %dms\n", elapsedTime);
+	        XP_WHITE;
+	    }
 
 		switch (diskPhase) {
 
@@ -1431,10 +1476,12 @@ static void vIfTask(void *pvParameters) {
 				eventString = "Unexpected";
 			}
 
-			XP_LT_CYAN
-			xprintf("\nIF Task ");
-			XP_WHITE;
-			xprintf("received event '%s' (0x%04x). Rx data = 0x%08x\r\n", eventString, event, rxData);
+			if (!g_fileRxActive) {
+				XP_LT_CYAN
+				xprintf("\nIF Task ");
+				XP_WHITE;
+				xprintf("received event '%s' (0x%04x). Rx data = 0x%08x\r\n", eventString, event, rxData);
+			}
 
 			old_state = if_task_state;
 
@@ -1501,7 +1548,7 @@ static void vIfTask(void *pvParameters) {
 				break;
 			}
 
-			if (old_state != if_task_state) {
+			if ((old_state != if_task_state) && !g_fileRxActive) {
 				// state has changed
 				XP_LT_CYAN;
 				xprintf("IF Task state changed ");
@@ -1652,9 +1699,11 @@ static void interprocessor_interrupt_assert(void) {
 	xprintf("Set PB11 as an output, driven to 0 (GPIO2). Read back as %d\n", pinValue);
 	XP_WHITE;
 #else
-	XP_LT_GREEN;
-	xprintf("Assert inter-processor interrupt.\n");
-	XP_WHITE;
+	if (!g_fileRxActive) {
+		XP_LT_GREEN;
+		xprintf("Assert inter-processor interrupt.\n");
+		XP_WHITE;
+	}
 #endif
 }
 
@@ -1676,9 +1725,11 @@ static void interprocessor_interrupt_negate(void) {
 	xprintf("Set PB11 as an output, drive to 1 (GPIO2). Read back as %d\n", pinValue);
 	XP_WHITE;
 #else
-	XP_LT_GREEN;
-	xprintf("Negate inter-processor interrupt.\n");
-	XP_WHITE;
+	if (!g_fileRxActive) {
+		XP_LT_GREEN;
+		xprintf("Negate inter-processor interrupt.\n");
+		XP_WHITE;
+	}
 #endif
 
 	// Now set PB11 as an input and prepare it to respond to interrupts from the MKL62BA.

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
@@ -44,6 +44,7 @@
 
 #include "crc16_ccitt.h"
 #include "fileRx.h"
+#include "inactivity.h"
 #include "ww500_md.h"
 #include "exif_utc.h"
 #include "barrier.h"
@@ -237,6 +238,16 @@ static fileRx_result_t  fileRxPendingErr;
 static fileOperation_t  fileRxOp;
 static uint8_t          fileRxPacketNum;
 
+// Inactivity period used while a file receive session is active. The standard
+// period (1000ms) is shorter than a slow BLE round trip, so the idle hook
+// could put the system into DPD between packets, killing the SD subsystem
+// mid-transfer (ftx err 7). Saved/restored around each session; if a session
+// dies without a CLOSE (e.g. BLE dropped), the extended period simply delays
+// the next DPD entry once — the period resets on wake from DPD.
+#define FILERX_SESSION_INACTIVITY_MS 5000
+static uint32_t savedInactivityPeriod;
+static bool     inactivityExtended = false;
+
 // This is the final string sent before we enter DPD
 //const char * lastMessage = "Sleep";
 
@@ -248,6 +259,19 @@ bool sendWakeMsg = false;
 static TickType_t fileRxStartTime;
 
 /*********************************** I2C Local Function Definitions ************************************************/
+
+/**
+ * Restore the inactivity period saved when the file receive session started.
+ *
+ * Called at every session end point: file close (success or error) and
+ * open failure. Safe to call when no extension is in force.
+ */
+static void restoreInactivityPeriod(void) {
+	if (inactivityExtended) {
+		inactivity_setPeriod(savedInactivityPeriod);
+		inactivityExtended = false;
+	}
+}
 
 /**
  * I2C slave callback - called when the Master has read our I2C data.
@@ -461,6 +485,16 @@ static void i2cRxDataReady(void) {
 			if_task_state = APP_IF_STATE_I2C_TX;
 			rearmI2C = false;
 			break;
+		}
+
+		// Session accepted: hold off DPD between packets (restored when the
+		// session closes — see restoreInactivityPeriod())
+		if (!inactivityExtended) {
+			savedInactivityPeriod = inactivity_getPeriod();
+			inactivityExtended    = true;
+			if (savedInactivityPeriod < FILERX_SESSION_INACTIVITY_MS) {
+				inactivity_setPeriod(FILERX_SESSION_INACTIVITY_MS);
+			}
 		}
 
 		fileRxOp.fileName      = (char *)fileRx_getFileName();
@@ -1229,6 +1263,7 @@ static APP_MSG_DEST_T  handleEventForStateDiskOp(APP_MSG_T rxMessage) {
 		case DISK_PHASE_FILE_OPEN:
 			if (fileRxOp.res != FR_OK) {
 				fileRxPendingErr = FILERX_ERR_FILE_OPEN;
+				restoreInactivityPeriod();	// session ends here — no CLOSE follows
 				snprintf(ackStr, sizeof(ackStr), "ftx err %d", (int)fileRxPendingErr);
 				sendI2CMessage((uint8_t *)ackStr, AI_PROCESSOR_MSG_RX_STRING, strlen(ackStr));
 			}
@@ -1266,6 +1301,9 @@ static APP_MSG_DEST_T  handleEventForStateDiskOp(APP_MSG_T rxMessage) {
 			break;
 
 		case DISK_PHASE_FILE_CLOSE:
+			// File closed: the session is over however we got here
+			restoreInactivityPeriod();
+
 			if (fileRxPendingErr != FILERX_OK) {
 				snprintf(ackStr, sizeof(ackStr), "ftx err %d", (int)fileRxPendingErr);
 			}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
@@ -95,9 +95,14 @@ static void wb_apply_yuv420(uint8_t *yuv, uint32_t w, uint32_t h,
 				int32_t G = Y - gOfs;
 				int32_t B = Y + bOfs;
 
-				if (R < 0) R = 0;
+				// Clamp BEFORE the gains: out-of-gamut YUV combinations push R/B
+				// past 255, and scaling those artifacts gives them more post-gain
+				// weight than genuinely saturated pixels - clipped highlights then
+				// come out unevenly tinted. Clamping first makes every saturated
+				// pixel respond to the gain identically (and matches G's handling).
+				if (R < 0) R = 0; else if (R > 255) R = 255;
 				if (G < 0) G = 0; else if (G > 255) G = 255;
-				if (B < 0) B = 0;
+				if (B < 0) B = 0; else if (B > 255) B = 255;
 
 				// White balance: scale red and blue (green is the reference)
 				R = (R * rGain) >> 8;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/xip_manager.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/xip_manager.c
@@ -336,9 +336,13 @@ static int init_flash(void) {
         return 0;
     }
 
+    bool opened = false;
+
     if (hx_lib_spi_eeprom_open(spi_inst) != 0) {
         xprintf("init_flash: failed to open SPI EEPROM\n");
         ret = -1;
+    } else {
+        opened = true;
     }
 
     if (ret == 0) {
@@ -350,8 +354,10 @@ static int init_flash(void) {
         }
     }
 
-    // Restore XIP: open() left the chip in SPI command mode.
-    if (ret == 0) {
+    // Restore XIP whenever open() succeeded - even if read_ID failed above.
+    // open() leaves the chip in SPI command mode; returning without
+    // re-enabling XIP hard-faults the next code/model fetch from flash.
+    if (opened) {
         if (hx_lib_spi_eeprom_enable_XIP(spi_inst, true, FLASH_QUAD, true) != 0) {
             xprintf("init_flash: failed to enable XIP\n");
             ret = -1;


### PR DESCRIPTION
## Summary

Makes BLE file receive on the WW500 **fast and reliable** — the Himax half of the fast-file-transfer work. Together with the nRF side (wildlifeai/ww-hardware#27) and the mobile app changes (already merged), this takes app → SD card transfers from **~0.24 KB/s to ~6–8 KB/s in bursts (~1.5 KB/s sustained on large files)**, verified end-to-end on hardware: a 512 KB file transfers, CRC-checks, and both firmware slots update over BLE from the cloud with no cable.

**Stacked on** #138 (`feat/camera-features-combined`) — this PR's diff shows only the transfer work. Merge #138 first; GitHub retargets this PR to `dev` automatically.

## Changes

- **SD write path reliability** (`fatfs_task.c`): `f_sync` cadence (every 16 writes) instead of per-packet; `f_sync` after `f_open(CREATE_ALWAYS)` so overwriting a large file doesn't fail on packet 1 (`ftx err 7`); transient write errors retried 3× with backoff; **short writes (volume full) fail fast** — no retry, since the file pointer already advanced; file-size cap raised to 10 MB for model files.
- **I2C slave deaf-window fix** (`if_task.c`): the receive buffer is re-armed **in the TX-done interrupt callback** rather than after a task-queue hop. At streaming rates the nRF writes the next packet immediately after reading our ACK; the task-hop delay clipped the frame header, the packet failed CRC silently, and the transfer stalled ("AI processor not responding").
- **Session-aware console logging**: per-packet hex dumps / state traces / event logs (~16 lines per packet at 921600 baud) are suppressed while a transfer session is active (`g_fileRxActive`) — they measurably throttled the packet loop. Everything logs normally outside transfers.
- **Missing-master window 1 s → 4 s**: survives brief BLE parameter renegotiations mid-transfer without tearing the session down.
- **Session inactivity hold**: DPD is held off while a transfer session is open (restored on close/abort).
- **Slot label robustness** (`camera_switch.c`): boot-slot variant labelling now logs every failure path and retries the flash write once — a silently lost label left the app's day/night camera switching stuck on "unknown" (seen once in the field after a dual-image update).
- **Review fixes**: white-balance clamps R/B before applying gains (uneven highlight tinting); `init_flash` always restores XIP when the SPI EEPROM was opened, even if `read_ID` fails (previously hard-faulted the next flash fetch).

## Testing

- 512 KB transfer completes with whole-file CRC verification, repeatedly, including the overwrite case.
- Full dual-image cloud update through the mobile app verified on a WW500 C02: download → BLE transfer → `firmware` flash with CRC pre-check → reset → verify, both variants.
- Known platform limit (documented in the mobile repo): Android holds the fast connection interval for only ~25 s per transfer, so large files run fast then settle at ~1.5 KB/s. Not device-side; iOS untested so far.
