### PR TITLE
RP3 image quality: live preview, auto-exposure, auto white balance + colour pipeline

### DIFF
--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c
@@ -133,6 +133,7 @@
 
 #include "barrier.h"
 #include "cisdp_sensor.h"
+#include "preview.h"
 
 #include "inactivity.h"
 
@@ -255,6 +256,8 @@ static BaseType_t prvWriteFile(char *pcWriteBuffer, size_t xWriteBufferLen, cons
 static BaseType_t prvReadFile(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString);
 static BaseType_t prvSend(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString);
 static BaseType_t prvCapture(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString);
+// Live image preview streaming over the console UART (see preview.c)
+static BaseType_t prvPreview(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString);
 static BaseType_t prvSetgps(char *pcWriteBuffer, size_t writeBufferLen, const char *pcCommandString);
 static BaseType_t prvGetgps(char *writeBuffer, size_t writeBufferLen, const char *commandString);
 static BaseType_t prvSetdid(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString);
@@ -567,6 +570,14 @@ static const CLI_Command_Definition_t xCapture = {
 	"capture <numCaptures> <timerDelay>:\r\n Capture <numCaptures> images at interval of <timerDelay> milliseconds\r\n",
 	prvCapture, /* The function to run. */
 	2			/* Two parameters expected */
+};
+
+/* Structure that defines the "preview" command line command. */
+static const CLI_Command_Definition_t xPreview = {
+	"preview", /* The command string to type. */
+	"preview <mode>:\r\n Live image preview on the console UART. 0=off, 1=stream (skip SD save), 2=stream+save.\r\n Then use 'capture <n> <ms>' to stream frames. View with _Tools/live_view.py\r\n",
+	prvPreview, /* The function to run. */
+	1			/* One parameter expected */
 };
 
 /* Structure that defines the "setop" command line command. */
@@ -1802,6 +1813,48 @@ static BaseType_t prvCapture(char *pcWriteBuffer, size_t xWriteBufferLen, const 
 }
 
 /**
+ * Turn live preview streaming on or off (see preview.c).
+ *
+ * Parameter: 0 = off, 1 = stream frames and skip the SD card save,
+ * 2 = stream frames and save to SD as normal.
+ *
+ * Streaming itself is driven by captures, e.g. 'capture 1000 0'.
+ */
+static BaseType_t prvPreview(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString) {
+	const char *pcParameter;
+	BaseType_t xParameterStringLength;
+	int mode;
+
+	pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 1, &xParameterStringLength);
+	if (pcParameter == NULL) {
+		snprintf(pcWriteBuffer, xWriteBufferLen,
+				"Error: mode required. 0=off, 1=stream (skip SD save), 2=stream+save.\r\n");
+		return pdFALSE;
+	}
+
+	mode = atoi(pcParameter);
+	if ((mode < PREVIEW_OFF) || (mode > PREVIEW_STREAM_AND_SAVE)) {
+		snprintf(pcWriteBuffer, xWriteBufferLen,
+				"Error: mode must be 0, 1 or 2.\r\n");
+		return pdFALSE;
+	}
+
+	preview_setMode((PREVIEW_MODE_E)mode);
+
+	if (mode == PREVIEW_OFF) {
+		snprintf(pcWriteBuffer, xWriteBufferLen, "Preview off.\r\n");
+	}
+	else {
+		snprintf(pcWriteBuffer, xWriteBufferLen,
+				"Preview mode %d (%s). Start frames with e.g. 'capture 1000 0'.\r\n",
+				mode,
+				(mode == PREVIEW_STREAM) ? "SD save skipped" : "SD save kept");
+	}
+
+	return pdFALSE;
+}
+
+/**
  * Set Operational Parameter
  *
  * Parameters: <index> <value>
@@ -2680,6 +2733,7 @@ static void vRegisterCLICommands(void)
 	FreeRTOS_CLIRegisterCommand(&xReadFile);
 	FreeRTOS_CLIRegisterCommand(&xSend);
 	FreeRTOS_CLIRegisterCommand(&xCapture);
+	FreeRTOS_CLIRegisterCommand(&xPreview);	// Live image preview streaming on the console UART
 
 	FreeRTOS_CLIRegisterCommand(&xSetGps);
 	FreeRTOS_CLIRegisterCommand(&xGetGps);

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
@@ -38,3 +38,9 @@
 27 286
 # 28: software white-balance BLUE gain, Q8.8 (256 = 1.0x, 0 = correction off). RP3 colour camera only.
 28 326
+# 29: RP camera auto-exposure: 0 = off, 1 = on.
+29 1
+# 30: auto-exposure target (raw p75 luma, 0 = built-in default).
+30 0
+# 31: RP camera white balance: 0 = off, 1 = auto, 2 = manual (op27/28).
+31 1

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
@@ -1,5 +1,5 @@
 # Description of the CONFIG.TXT File
-#### CGP - 25 April 2026 (updated 8 July 2026: parameters 21-28, immediate persistence)
+#### CGP - 25 April 2026 (updated 11 July 2026: parameters 29-31 - RP camera auto-exposure and white-balance mode)
 
 The CONFIG.TXT file contains "Operational Parameters" for the WW500.
 
@@ -68,6 +68,9 @@ captured first.
 |    26 | OP_PARAMETER_SLOT_SWITCH 				| 0             | Automatic light-based camera image switching: 0 = off (manual `switchslot` only), 1 = automatic (night image in the dark, colour image in daylight; reboots at the next sleep) |
 |    27 | OP_PARAMETER_WB_RED_GAIN 				| 286           | Software white-balance RED gain, Q8.8 (256 = 1.0x, 0 = correction off). RP3 colour camera only |
 |    28 | OP_PARAMETER_WB_BLUE_GAIN 				| 326           | Software white-balance BLUE gain, Q8.8 (256 = 1.0x, 0 = correction off). RP3 colour camera only |
+|    29 | OP_PARAMETER_CAM_AE_ENABLE 			| 1             | RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. Highlight-metered loop steps sensor exposure (8-5000 lines) then analog gain (to 16x) toward the target - see `ae.c` |
+|    30 | OP_PARAMETER_CAM_AE_TARGET 			| 110           | Auto-exposure target: raw bright-quartile (p75) luma, 0-250 (0 = built-in default 95). Bright parts of the scene render just below white after the tone curve |
+|    31 | OP_PARAMETER_CAM_WB_MODE 				| 1             | RP camera white balance: 0 = off (hardware JPEG), 1 = auto (warmth-biased grey-world measured per frame), 2 = manual op27/op28. Auto falls back to manual for flash-lit or too-dark frames - see `img_correct.c` |
 
 ## More Details
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.c
@@ -1,0 +1,179 @@
+/*
+ * ae.c
+ *
+ * Minimal auto-exposure for the RP (Sony IMX) cameras. See ae.h.
+ *
+ * Control law: work in the product domain P = exposure_lines x gain (the
+ * total light multiplier), scale P by target/measured each step (damped),
+ * then split P back into exposure first, analog gain for the remainder.
+ *
+ * Bench measurements behind the constants (10 Jul 2026, see
+ * _Documentation/rp3-image-quality-plan.md):
+ *   - exposure responds linearly ~100..5000+ lines (no frame-length clamp
+ *     seen up to 5120)
+ *   - analog gain works across the full Sony range (code 0..960 = 1..16x)
+ *   - the sensor pedestal shows as a constant offset in the Y plane
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "WE2_core.h"		// SCB_InvalidateDCache_by_Addr
+#include "xprintf.h"
+
+#include "hx_drv_CIS_common.h"	// hx_drv_cis_set_reg
+#include "fatfs_task.h"		// operational parameters
+#include "preview.h"		// preview_isActive(): unbounded AE while previewing
+#include "ae.h"
+
+// Sony register layout (IMX708/IMX219): 16-bit big-endian pairs
+#define AE_REG_EXPOSURE_H	0x0202
+#define AE_REG_EXPOSURE_L	0x0203
+#define AE_REG_GAIN_H		0x0204
+#define AE_REG_GAIN_L		0x0205
+
+#define AE_EXPOSURE_DEFAULT	0x0940	// the init-table value (IMX708_EXPOSURE_SETTING)
+#define AE_EXPOSURE_MIN		8		// lines (bright daylight needs very short exposures)
+#define AE_EXPOSURE_MAX		5000	// lines (bench-verified; frame time grows beyond)
+#define AE_GAIN_CODE_MAX	960		// 16x  (gain = 1024 / (1024 - code))
+#define AE_GAIN_Q8_UNITY	256
+#define AE_GAIN_Q8_MAX		4096	// 16x in Q8.8
+
+#define AE_PEDESTAL			16		// sensor black pedestal in the Y plane
+// Highlight-weighted metering: expose so the bright quartile (p75) of the
+// frame sits here. Mean metering underexposes high-key scenes (a mostly-white
+// subject gets dragged to grey); anchoring the bright parts renders them just
+// below white after the tone curve, like a phone's metering.
+#define AE_TARGET_DEFAULT	95		// raw p75 target (op30: 0 = this default)
+#define AE_DEADBAND			8		// no adjustment within +/- this of target
+// Per-step damping: scale ratio clamped to [1/3 .. 3] (Q8: 85..768)
+#define AE_RATIO_Q8_MIN		85
+#define AE_RATIO_Q8_MAX		768
+#define AE_MAX_STEPS_PER_WAKE	3	// battery bound (ignored during live preview)
+
+static uint16_t curExposure = AE_EXPOSURE_DEFAULT;
+static uint16_t curGainCode = 0;
+static uint8_t stepsThisWake = 0;
+
+void ae_notifySensorInit(void) {
+	// Registers just reverted to the init tables (+ any camreg staged file)
+	curExposure = AE_EXPOSURE_DEFAULT;
+	curGainCode = 0;
+	stepsThisWake = 0;
+}
+
+/**
+ * Bright-quartile (p75) luma of the Y plane, subsampled every 8th pixel.
+ * Uses a 32-bin histogram: finds the bin where the cumulative count crosses
+ * 75%, then refines with the bin's midpoint.
+ */
+static uint32_t brightLuma(uint32_t yAddr, uint16_t w, uint16_t h) {
+	const uint8_t *y = (const uint8_t *)yAddr;
+	uint32_t hist[32] = {0};
+	uint32_t n = 0;
+
+	SCB_InvalidateDCache_by_Addr((void *)yAddr, (int32_t)((uint32_t)w * h));
+
+	for (uint16_t row = 0; row < h; row += 8) {
+		const uint8_t *line = y + ((uint32_t)row * w);
+		for (uint16_t col = 0; col < w; col += 8) {
+			hist[line[col] >> 3]++;
+			n++;
+		}
+	}
+	if (n == 0) {
+		return 0;
+	}
+
+	uint32_t threshold = (n * 3u) / 4u;		// 75th percentile
+	uint32_t cum = 0;
+	for (int bin = 0; bin < 32; bin++) {
+		cum += hist[bin];
+		if (cum >= threshold) {
+			return ((uint32_t)bin << 3) + 4;	// bin midpoint
+		}
+	}
+	return 255;
+}
+
+static void writeReg16(uint16_t regH, uint16_t value) {
+	// hx_drv_cis_set_reg(addr, val, 0) - same call the camreg command uses
+	hx_drv_cis_set_reg(regH, (uint8_t)((value >> 8) & 0xFF), 0);
+	hx_drv_cis_set_reg((uint16_t)(regH + 1), (uint8_t)(value & 0xFF), 0);
+}
+
+bool ae_process(uint32_t yAddr, uint16_t w, uint16_t h) {
+	if (fatfs_getOperationalParameter(OP_PARAMETER_CAM_AE_ENABLE) == 0) {
+		return false;
+	}
+	if ((stepsThisWake >= AE_MAX_STEPS_PER_WAKE) && !preview_isActive()) {
+		return false;
+	}
+	if ((yAddr == 0) || (w == 0) || (h == 0)) {
+		return false;
+	}
+
+	uint32_t measured = brightLuma(yAddr, w, h);
+
+	uint32_t target = fatfs_getOperationalParameter(OP_PARAMETER_CAM_AE_TARGET);
+	if ((target == 0) || (target > 250)) {
+		target = AE_TARGET_DEFAULT;
+	}
+
+	int32_t error = (int32_t)measured - (int32_t)target;
+	if ((error >= -AE_DEADBAND) && (error <= AE_DEADBAND)) {
+		return false;	// close enough
+	}
+
+	// Pedestal-corrected proportional ratio (Q8)
+	uint32_t mEff = (measured > (AE_PEDESTAL + 2)) ? (measured - AE_PEDESTAL) : 2;
+	uint32_t tEff = (target > AE_PEDESTAL) ? (target - AE_PEDESTAL) : 2;
+	uint32_t ratioQ8 = (tEff << 8) / mEff;
+	if (ratioQ8 < AE_RATIO_Q8_MIN) ratioQ8 = AE_RATIO_Q8_MIN;
+	if (ratioQ8 > AE_RATIO_Q8_MAX) ratioQ8 = AE_RATIO_Q8_MAX;
+
+	// Total light product P (lines, gain folded in), then rescale
+	uint32_t gainQ8 = (1024u << 8) / (1024u - curGainCode);
+	uint32_t pLines = ((uint32_t)curExposure * gainQ8) >> 8;	// <= 80k
+	uint32_t newP = (pLines * ratioQ8) >> 8;					// <= 240k
+	if (newP < AE_EXPOSURE_MIN) {
+		newP = AE_EXPOSURE_MIN;
+	}
+
+	// Split: exposure first, remainder into analog gain
+	uint32_t newExposure = newP;
+	if (newExposure > AE_EXPOSURE_MAX) newExposure = AE_EXPOSURE_MAX;
+	if (newExposure < AE_EXPOSURE_MIN) newExposure = AE_EXPOSURE_MIN;
+
+	uint32_t newGainQ8 = (newP << 8) / newExposure;
+	if (newGainQ8 < AE_GAIN_Q8_UNITY) newGainQ8 = AE_GAIN_Q8_UNITY;
+	if (newGainQ8 > AE_GAIN_Q8_MAX) newGainQ8 = AE_GAIN_Q8_MAX;
+
+	uint32_t newGainCode = 1024u - ((1024u << 8) / newGainQ8);
+	if (newGainCode > AE_GAIN_CODE_MAX) newGainCode = AE_GAIN_CODE_MAX;
+
+	// Skip the write if the change is negligible (avoids register churn)
+	uint32_t expDelta = (newExposure > curExposure) ? (newExposure - curExposure)
+			: (curExposure - newExposure);
+	uint32_t gainDelta = (newGainCode > curGainCode) ? (newGainCode - curGainCode)
+			: (curGainCode - newGainCode);
+	if ((expDelta < (curExposure / 20u)) && (gainDelta < 8)) {
+		return false;
+	}
+
+	xprintf("AE: p75=%d (target %d) exposure %d->%d gain code %d->%d\n",
+			(int)measured, (int)target,
+			(int)curExposure, (int)newExposure,
+			(int)curGainCode, (int)newGainCode);
+
+	if (newExposure != curExposure) {
+		writeReg16(AE_REG_EXPOSURE_H, (uint16_t)newExposure);
+		curExposure = (uint16_t)newExposure;
+	}
+	if (newGainCode != curGainCode) {
+		writeReg16(AE_REG_GAIN_H, (uint16_t)newGainCode);
+		curGainCode = (uint16_t)newGainCode;
+	}
+	stepsThisWake++;
+	return true;
+}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.h
@@ -1,0 +1,47 @@
+/*
+ * ae.h
+ *
+ * Minimal auto-exposure for the RP (Sony IMX) cameras.
+ *
+ * The IMX708/IMX219 are raw sensors with no on-sensor AE, and the WE2
+ * datapath has none either, so exposure was a hardcoded register value
+ * (0x0202 = 0x0940) and images were dim or blown depending on the light.
+ *
+ * This module runs after each captured frame: it measures the mean of the
+ * Y plane the HW5x5 wrote to memory, compares it with a target, and steps
+ * the sensor's exposure (0x0202/03) and analog gain (0x0204/05) toward the
+ * target. Exposure is used first; analog gain (up to 16x) only when the
+ * exposure range (bench-verified 100..5000 lines) is not enough.
+ *
+ * Bounded to a few adjustments per wake cycle to protect the battery;
+ * unbounded while live preview is active (see preview.c) so convergence
+ * is visible in the stream.
+ *
+ * Op-params: OP_PARAMETER_CAM_AE_ENABLE (0 = off), OP_PARAMETER_CAM_AE_TARGET
+ * (target mean luma, default 110). Bench data: _Documentation/rp3-image-quality-plan.md
+ */
+
+#ifndef AE_H_
+#define AE_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * Reset AE state to the sensor's table defaults. Call after a full sensor
+ * init (cisdp_sensor_init(true)) - the registers have just reverted, so the
+ * loop must restart from the table values.
+ */
+void ae_notifySensorInit(void);
+
+/**
+ * Measure the frame and adjust exposure/gain toward the target.
+ * Call from the image task on FRAME_READY, before the next capture is armed.
+ *
+ * @param yAddr  address of the Y plane (demosaic output, w*h bytes)
+ * @param w,h    frame dimensions
+ * @return true if a register adjustment was made (next frame will differ)
+ */
+bool ae_process(uint32_t yAddr, uint16_t w, uint16_t h);
+
+#endif /* AE_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -246,6 +246,9 @@ uint16_t op_parameter[OP_PARAMETER_NUM_ENTRIES] = {
 	1,	    	   		// 26 OP_PARAMETER_SLOT_SWITCH (0 = off/manual only; 1 = automatic light-based switching)
 	286,	   			// 27 OP_PARAMETER_WB_RED_GAIN (Q8.8: 286 = x1.117, the bench-measured neutralising gain; 0 disables)
 	326,	   			// 28 OP_PARAMETER_WB_BLUE_GAIN (Q8.8: 326 = x1.273, the bench-measured neutralising gain; 0 disables)
+	1,	    	   		// 29 OP_PARAMETER_CAM_AE_ENABLE (RP camera auto-exposure on/off - see ae.c)
+	110,	   			// 30 OP_PARAMETER_CAM_AE_TARGET (target mean luma; 0 = built-in default)
+	1,	    	   		// 31 OP_PARAMETER_CAM_WB_MODE (1 = auto grey-world; 2 = manual op27/28; 0 = off)
 };
 
 // Deployment ID UUID string — loaded from 'I ' line in CONFIG.TXT or set via setdid CLI command

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
@@ -89,6 +89,9 @@ typedef enum {
 	OP_PARAMETER_SLOT_SWITCH,		// 26 Automatic light-based camera image switching: 0 = off (manual 'switchslot' only), 1 = automatic (PLANNED - see camera_switch.c)
 	OP_PARAMETER_WB_RED_GAIN,		// 27 Software white-balance red gain, Q8.8 (256 = 1.0x, 0 = correction off). RP camera only - see img_correct.c
 	OP_PARAMETER_WB_BLUE_GAIN,		// 28 Software white-balance blue gain, Q8.8 (256 = 1.0x, 0 = correction off). RP camera only - see img_correct.c
+	OP_PARAMETER_CAM_AE_ENABLE,		// 29 RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. See ae.c
+	OP_PARAMETER_CAM_AE_TARGET,		// 30 RP camera auto-exposure target mean luma (0-250; 0 = built-in default 110). See ae.c
+	OP_PARAMETER_CAM_WB_MODE,		// 31 RP camera white balance: 0 = off, 1 = auto (grey-world per frame), 2 = manual op27/op28. See img_correct.c
 
 	OP_PARAMETER_NUM_ENTRIES		// Not an Operational Parameters - serves to define the size of the op_parameter[] array
 } OP_PARAMETERS_E;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
@@ -79,6 +79,8 @@
 #include "exif_gps.h"
 #include "exif_builder.h"
 #include "img_correct.h"
+#include "preview.h"
+#include "ae.h"
 
 /*************************************** Definitions *******************************************/
 
@@ -245,7 +247,7 @@ static bool g_wdt_event; 		// A watchdog timer event occurred while waiting for 
 // than tear the camera down and give up (which loses the capture request and,
 // for a console 'capture', leaves the image task Uninitialised so every later
 // capture is dropped), restart the sensor in place and try again a few times.
-#define MAX_CAPTURE_RETRIES 3
+#define MAX_CAPTURE_RETRIES 5
 static uint8_t g_capture_retries;	// in-place retries used for the current capture
 
 // True when this wake exists only to sample the light level (AE registers) for
@@ -947,12 +949,38 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
 #endif // 0
 #endif // #if defined(USE_HM0360) || defined(USE_HM0360_MD)
 
+#if defined(USE_RP2) || defined(USE_RP3)
+        // Auto-exposure for the RP camera (raw sensor, no on-sensor AE - see
+        // ae.c). Adjusts exposure/gain registers for the NEXT frame.
+        if (!aeCheckOnlyWake) {
+        	ae_process(app_get_raw_addr(),
+        			(uint16_t)app_get_raw_width(), (uint16_t)app_get_raw_height());
+        }
+#endif // USE_RP2 || USE_RP3
+
+        // Live preview (see preview.c): stream this frame over the console UART.
+        // AE-check wakes are not streamed - they are brief housekeeping captures.
+        bool previewFrame = preview_isActive() && !aeCheckOnlyWake;
+
         if (aeCheckOnlyWake
-        		|| (fatfs_getOperationalParameter(OP_PARAMETER_TEST_MODE_BITS) & TEST_BIT_SKIP_FILE_CREATION)) {
+        		|| (fatfs_getOperationalParameter(OP_PARAMETER_TEST_MODE_BITS) & TEST_BIT_SKIP_FILE_CREATION)
+        		|| (previewFrame && preview_skipsFileSave())) {
         	// Don't save to a file. This allows faster streaming of MD and AE data to the app
         	fileOp.fileName = NULL; // skip file write!
         	fileOp.senderQueue = xImageTaskQueue; // necessary so the response comes to this task.
         	xprintf("Skipping file save.\n");
+
+#if defined(USE_RP2) || defined(USE_RP3)
+        	if (previewFrame) {
+        		// The preview must show what a saved file would look like, so run
+        		// the same software white-balance correction the save path runs
+        		img_correct_process_mode(
+        				(uint8_t)fatfs_getOperationalParameter(OP_PARAMETER_CAM_WB_MODE),
+        				(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_RED_GAIN),
+        				(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN),
+        				ledFlashIsActive());
+        	}
+#endif // USE_RP2 || USE_RP3
         }
         else {
         	// Normal processing: create the jpg or bmp file
@@ -962,10 +990,12 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
         	// pipeline (raw Bayer sensor + WE2 demosaic only), so images come out
         	// green. Correct the YUV frame in software and re-encode it with a
         	// software JPEG encoder (sw_jpeg.c); prepareJpegFile() then uses the corrected
-        	// JPEG. Gains are app-tunable Operational Parameters (0 disables).
-        	img_correct_process(
+        	// JPEG. Mode op31: 0 = off, 1 = auto grey-world, 2 = manual op27/op28.
+        	img_correct_process_mode(
+        			(uint8_t)fatfs_getOperationalParameter(OP_PARAMETER_CAM_WB_MODE),
         			(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_RED_GAIN),
-        			(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN));
+        			(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN),
+        			ledFlashIsActive());
 #endif // USE_RP2 || USE_RP3
 
 #ifdef INVESTIGATE_BMP
@@ -1003,6 +1033,12 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
         	prepareJpegFile(outCategories, classCount, &extraBlock);
 #endif // INVESTIGATE_BMP
 
+        }
+
+        if (previewFrame) {
+        	// Stream the frame (blocks this task for the UART write; the fatfs
+        	// write below only starts afterwards, so the JPEG buffer is stable)
+        	preview_sendFrame();
         }
 
         // Proceed to write the jpeg file, even if there is no SD card
@@ -1065,8 +1101,14 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
             		g_capture_retries, MAX_CAPTURE_RETRIES);
             XP_WHITE;
 
-            // Stop then restart the datapath/sensor to re-arm the capture
+            // Stop then restart the datapath/sensor to re-arm the capture.
+            // Dwell progressively longer with the sensor powered down before
+            // each restart: the MIPI bring-up is timing-marginal and
+            // back-to-back restarts can fail identically (bench 10-11 Jul:
+            // 15 instant retries failed where a later boot succeeded first
+            // try). Varying the dwell samples different phase alignments.
             configure_image_sensor(CAMERA_CONFIG_STOP);
+            vTaskDelay(pdMS_TO_TICKS(100u * g_capture_retries));
             if (configure_image_sensor(CAMERA_CONFIG_RUN)) {
                 // Restart the timeout clock and keep waiting for FRAME_READY
                 startTime = xTaskGetTickCount();
@@ -1843,6 +1885,12 @@ static bool configure_image_sensor(CAMERA_CONFIG_E operation) {
 #endif // USE_HM0360
         	// Initialise extra registers from file
         	cis_file_process(CAMERA_EXTRA_FILE);
+
+#if defined(USE_RP2) || defined(USE_RP3)
+        	// Sensor registers just reverted to the tables (+ staged file):
+        	// restart the auto-exposure loop from the table values (ae.c)
+        	ae_notifySensorInit();
+#endif // USE_RP2 || USE_RP3
 
         	// if wdma variable is zero when not init yet, then this step is a must be to retrieve wdma address
         	//  Datapath events give callbacks to os_app_dplib_cb()

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
@@ -34,6 +34,48 @@
 // comparable to the hardware encoder's 4x table.
 #define IMG_CORRECT_JPEG_QUALITY  85
 
+/*
+ * Phase C colour pipeline (order mirrors the Raspberry Pi ISP for this
+ * sensor): black level -> WB gains -> colour correction matrix -> gamma.
+ * Reference data from libcamera's imx708.json tuning file - see
+ * _Documentation/rp3-image-quality-plan.md section 2.
+ */
+
+// Sensor black pedestal (imx708.json black_level 4096/65536 = 16/255) and the
+// x256 rescale that restores full range after subtraction: 256*255/(255-16)
+#define BLACK_LEVEL			16
+#define BLACK_RESCALE_Q8	273
+
+// 4640 K colour correction matrix, Q8.8, rows renormalised to sum 256.
+// (Daylight-ish; good general default. CCT-switched blending is Phase C3.)
+static const int32_t CCM_Q8[9] = {
+	392,  -90,  -46,
+	-72,  427,  -99,
+	  4, -146,  398,
+};
+
+// Gamma LUT from the imx708.json contrast curve (16-bit anchors 0->0,
+// 1024->5040, 4096->15312, 16384->40642, 65535->65535), resampled to 8-bit.
+// Strong shadow lift, gentle highlight shoulder.
+static const uint8_t GAMMA_LUT[256] = {
+	  0,   5,  10,  15,  20,  23,  26,  30,  33,  36,  40,  43,  46,  50,  53,  56,
+	 60,  62,  64,  66,  68,  70,  72,  74,  76,  78,  80,  82,  84,  87,  89,  91,
+	 93,  95,  97,  99, 101, 103, 105, 107, 109, 111, 113, 115, 117, 119, 122, 124,
+	126, 128, 130, 132, 134, 136, 138, 140, 142, 144, 146, 148, 150, 152, 155, 157,
+	158, 159, 159, 160, 160, 161, 161, 162, 162, 163, 163, 164, 164, 165, 165, 166,
+	166, 167, 167, 168, 168, 169, 169, 170, 170, 171, 171, 172, 172, 173, 173, 174,
+	174, 175, 175, 176, 176, 177, 178, 178, 179, 179, 180, 180, 181, 181, 182, 182,
+	183, 183, 184, 184, 185, 185, 186, 186, 187, 187, 188, 188, 189, 189, 190, 190,
+	191, 191, 192, 192, 193, 193, 194, 194, 195, 195, 196, 196, 197, 197, 198, 198,
+	199, 199, 200, 200, 201, 201, 202, 202, 203, 203, 204, 204, 205, 205, 206, 206,
+	207, 207, 208, 208, 209, 209, 210, 210, 211, 211, 212, 212, 213, 213, 214, 214,
+	215, 215, 216, 217, 217, 218, 218, 219, 219, 220, 220, 221, 221, 222, 222, 223,
+	223, 224, 224, 225, 225, 226, 226, 227, 227, 228, 228, 229, 229, 230, 230, 231,
+	231, 232, 232, 233, 233, 234, 234, 235, 235, 236, 236, 237, 237, 238, 238, 239,
+	239, 240, 240, 241, 241, 242, 242, 243, 243, 244, 244, 245, 245, 246, 246, 247,
+	247, 248, 248, 249, 249, 250, 250, 251, 251, 252, 252, 253, 253, 254, 254, 255,
+};
+
 /*************************************** Local variables *********************/
 
 // Valid when the last capture was corrected + re-encoded
@@ -104,11 +146,29 @@ static void wb_apply_yuv420(uint8_t *yuv, uint32_t w, uint32_t h,
 				if (G < 0) G = 0; else if (G > 255) G = 255;
 				if (B < 0) B = 0; else if (B > 255) B = 255;
 
+				// Black level: subtract the sensor pedestal, restore range
+				R = (R > BLACK_LEVEL) ? (((R - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+				G = (G > BLACK_LEVEL) ? (((G - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+				B = (B > BLACK_LEVEL) ? (((B - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+
 				// White balance: scale red and blue (green is the reference)
 				R = (R * rGain) >> 8;
 				B = (B * bGain) >> 8;
 				if (R > 255) R = 255;
 				if (B > 255) B = 255;
+
+				// Colour correction matrix (4640 K, Q8.8)
+				int32_t Rc = (CCM_Q8[0] * R + CCM_Q8[1] * G + CCM_Q8[2] * B) >> 8;
+				int32_t Gc = (CCM_Q8[3] * R + CCM_Q8[4] * G + CCM_Q8[5] * B) >> 8;
+				int32_t Bc = (CCM_Q8[6] * R + CCM_Q8[7] * G + CCM_Q8[8] * B) >> 8;
+				if (Rc < 0) Rc = 0; else if (Rc > 255) Rc = 255;
+				if (Gc < 0) Gc = 0; else if (Gc > 255) Gc = 255;
+				if (Bc < 0) Bc = 0; else if (Bc > 255) Bc = 255;
+
+				// Tone curve
+				R = GAMMA_LUT[Rc];
+				G = GAMMA_LUT[Gc];
+				B = GAMMA_LUT[Bc];
 
 				// Back to YCbCr (JPEG full range)
 				int32_t newY = (77 * R + 150 * G + 29 * B) >> 8;
@@ -129,7 +189,119 @@ static void wb_apply_yuv420(uint8_t *yuv, uint32_t w, uint32_t h,
 	}
 }
 
+/*************************************** Auto white balance ******************/
+
+// Warmth bias so "balanced" matches the phone reference rendering rather than
+// strict grey: measured target on the bright quartile is G/R ~ 0.94 (red a
+// touch above green) and G/B ~ 1.06 (blue a touch below). x256 fixed point.
+#define WB_AUTO_R_BIAS_Q8	271		// 1.06: red ends ~6% above grey-world
+#define WB_AUTO_B_BIAS_Q8	242		// 0.94: blue ends ~6% below grey-world
+#define WB_AUTO_GAIN_MIN	230		// 0.9x  - clamp band from the imx708.json
+#define WB_AUTO_GAIN_MAX	640		// 2.5x    CT-curve endpoints, with margin
+#define WB_AUTO_PEDESTAL	16		// sensor black pedestal, subtracted first
+
+/**
+ * Grey-world measurement: subsampled RGB means of the YUV420 frame.
+ * Samples every 4th chroma column of every 4th chroma row (1/16 of blocks).
+ */
+static void wb_measure_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
+							  uint32_t *rMean, uint32_t *gMean, uint32_t *bMean) {
+	const uint8_t *yPlane = yuv;
+	const uint8_t *uPlane = yuv + (w * h);
+	const uint8_t *vPlane = uPlane + ((w * h) >> 2);
+	uint32_t cw = w >> 1;
+	uint32_t ch = h >> 1;
+	uint32_t rSum = 0, gSum = 0, bSum = 0, n = 0;
+
+	for (uint32_t cy = 0; cy < ch; cy += 4) {
+		const uint8_t *u = uPlane + cy * cw;
+		const uint8_t *v = vPlane + cy * cw;
+		const uint8_t *y0 = yPlane + (cy * 2) * w;
+
+		for (uint32_t cx = 0; cx < cw; cx += 4) {
+			int32_t Y = y0[cx * 2];
+			int32_t cb = (int32_t)u[cx] - 128;
+			int32_t cr = (int32_t)v[cx] - 128;
+
+			int32_t R = Y + ((359 * cr) >> 8);
+			int32_t G = Y - ((88 * cb + 183 * cr) >> 8);
+			int32_t B = Y + ((454 * cb) >> 8);
+			if (R < 0) R = 0; else if (R > 255) R = 255;
+			if (G < 0) G = 0; else if (G > 255) G = 255;
+			if (B < 0) B = 0; else if (B > 255) B = 255;
+
+			rSum += (uint32_t)R;
+			gSum += (uint32_t)G;
+			bSum += (uint32_t)B;
+			n++;
+		}
+	}
+	if (n == 0) n = 1;
+	*rMean = rSum / n;
+	*gMean = gSum / n;
+	*bMean = bSum / n;
+}
+
+/**
+ * Compute warmth-biased grey-world gains for the current frame.
+ * Returns false if the frame is too dark to measure reliably.
+ */
+static bool wb_auto_gains(const uint8_t *yuv, uint32_t w, uint32_t h,
+						  uint16_t *rGainQ8, uint16_t *bGainQ8) {
+	uint32_t rM, gM, bM;
+	wb_measure_yuv420(yuv, w, h, &rM, &gM, &bM);
+
+	// Pedestal-correct; if the scene is essentially black, don't guess
+	rM = (rM > WB_AUTO_PEDESTAL) ? (rM - WB_AUTO_PEDESTAL) : 0;
+	gM = (gM > WB_AUTO_PEDESTAL) ? (gM - WB_AUTO_PEDESTAL) : 0;
+	bM = (bM > WB_AUTO_PEDESTAL) ? (bM - WB_AUTO_PEDESTAL) : 0;
+	if ((gM < 4) || (rM < 2) || (bM < 2)) {
+		return false;
+	}
+
+	uint32_t rGain = (WB_AUTO_R_BIAS_Q8 * gM) / rM;
+	uint32_t bGain = (WB_AUTO_B_BIAS_Q8 * gM) / bM;
+	if (rGain < WB_AUTO_GAIN_MIN) rGain = WB_AUTO_GAIN_MIN;
+	if (rGain > WB_AUTO_GAIN_MAX) rGain = WB_AUTO_GAIN_MAX;
+	if (bGain < WB_AUTO_GAIN_MIN) bGain = WB_AUTO_GAIN_MIN;
+	if (bGain > WB_AUTO_GAIN_MAX) bGain = WB_AUTO_GAIN_MAX;
+
+	xprintf("WB auto: means R=%u G=%u B=%u -> gains R x%u/256, B x%u/256\n",
+			(unsigned)rM, (unsigned)gM, (unsigned)bM,
+			(unsigned)rGain, (unsigned)bGain);
+
+	*rGainQ8 = (uint16_t)rGain;
+	*bGainQ8 = (uint16_t)bGain;
+	return true;
+}
+
 /*************************************** Public API **************************/
+
+bool img_correct_process_mode(uint8_t mode, uint16_t rManualQ8, uint16_t bManualQ8,
+							  bool flashLit) {
+	if (mode == IMG_CORRECT_MODE_OFF) {
+		corrected_valid = false;
+		return false;
+	}
+	if (mode == IMG_CORRECT_MODE_AUTO && !flashLit) {
+		uint32_t yuvAddr = app_get_raw_addr();
+		uint32_t w = app_get_raw_width();
+		uint32_t h = app_get_raw_height();
+		uint16_t rAuto, bAuto;
+
+		if ((yuvAddr != 0) && (w != 0) && (h != 0)) {
+			// The frame is DMA-written; refresh the CPU's view before measuring
+			SCB_InvalidateDCache_by_Addr((void *)yuvAddr, (int32_t)((w * h * 3) / 2));
+			if (wb_auto_gains((const uint8_t *)yuvAddr, w, h, &rAuto, &bAuto)) {
+				return img_correct_process(rAuto, bAuto);
+			}
+		}
+		// Too dark / no buffer: fall through to the manual gains
+	}
+	// Manual mode, flash-lit frame (spectrum differs - keep it predictable),
+	// or auto measurement failed
+	return img_correct_process(rManualQ8, bManualQ8);
+}
 
 bool img_correct_process(uint16_t rGainQ8, uint16_t bGainQ8) {
 	corrected_valid = false;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.h
@@ -48,6 +48,22 @@
  */
 bool img_correct_process(uint16_t rGainQ8, uint16_t bGainQ8);
 
+// WB modes for img_correct_process_mode() (op-param OP_PARAMETER_CAM_WB_MODE)
+#define IMG_CORRECT_MODE_OFF	0	// no correction, hardware sensor-path JPEG
+#define IMG_CORRECT_MODE_AUTO	1	// warmth-biased grey-world, measured per frame
+#define IMG_CORRECT_MODE_MANUAL	2	// fixed gains from op27/op28
+
+/**
+ * Mode-dispatching wrapper around img_correct_process().
+ *
+ * AUTO measures the frame (subsampled grey-world with a warmth bias matched
+ * to the phone-reference rendering) and applies the computed gains; it falls
+ * back to the manual gains for flash-lit frames (different spectrum), frames
+ * too dark to measure, or if measurement is unavailable.
+ */
+bool img_correct_process_mode(uint8_t mode, uint16_t rManualQ8, uint16_t bManualQ8,
+							  bool flashLit);
+
 /**
  * If the last capture was corrected and re-encoded, overwrite *size and *addr
  * with the corrected JPEG's size and address; otherwise leave them untouched.

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
@@ -1,0 +1,144 @@
+/*
+ * preview.c
+ *
+ * Live image preview over the console UART. See preview.h and
+ * _Documentation/live_preview.md
+ *
+ * Frame line format (one line per frame, CR ... LF):
+ *
+ *   {"type": 1, "name": "INVOKE", "code": 0, "data": {"count": N,
+ *    "resolution": [W, H], "boxes": [], "image": "<base64 JPEG>"}}
+ *
+ * This is the same framing the Himax/SSCMA scenario apps use (see
+ * app/scenario_app/tflm_fd_fm/send_result.cpp), so as well as
+ * _Tools/live_view.py the Himax AI web toolkit can display the stream.
+ *
+ * The base64 is generated and written in small chunks so no frame-sized
+ * buffer is needed. Writes go through xprintf() like all other console
+ * output; a console print from another task can occasionally land inside
+ * a frame line, which corrupts that frame only - the viewer drops it and
+ * carries on.
+ *
+ * Bandwidth: 921600 baud is ~92 KB/s. A VGA JPEG is typically 25-50 KB,
+ * +33% for base64, so expect roughly 1.5-2.5 fps from 'capture 1000 0'.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "WE2_core.h"		// SCB_InvalidateDCache_by_Addr
+#include "xprintf.h"
+
+#include "cisdp_sensor.h"	// cisdp_get_jpginfo(), app_get_raw_width/height()
+#include "img_correct.h"	// img_correct_get_jpeg()
+#include "preview.h"
+
+// A VGA JPEG should be well under this; anything bigger means the JPEG
+// info is implausible and the frame is skipped rather than streamed.
+#define PREVIEW_MAX_JPEG_BYTES	(200 * 1024)
+
+// Base64 input chunk. Must be a multiple of 3 so '=' padding can only
+// occur at the very end of the frame.
+#define PREVIEW_CHUNK_IN	510
+
+static volatile PREVIEW_MODE_E previewMode = PREVIEW_OFF;
+static uint32_t frameCount = 0;
+
+static const char BASE64_CHARS[] =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+void preview_setMode(PREVIEW_MODE_E mode) {
+	previewMode = mode;
+	if (mode == PREVIEW_OFF) {
+		frameCount = 0;
+	}
+}
+
+PREVIEW_MODE_E preview_getMode(void) {
+	return previewMode;
+}
+
+bool preview_isActive(void) {
+	return (previewMode != PREVIEW_OFF);
+}
+
+bool preview_skipsFileSave(void) {
+	return (previewMode == PREVIEW_STREAM);
+}
+
+/**
+ * Base64-encode data and write it to the console in chunks.
+ */
+static void sendBase64(const uint8_t *data, uint32_t length) {
+	// 4 output chars per 3 input bytes, + NUL
+	static char out[((PREVIEW_CHUNK_IN / 3) * 4) + 1];
+
+	while (length > 0) {
+		uint32_t n = (length > PREVIEW_CHUNK_IN) ? PREVIEW_CHUNK_IN : length;
+		uint32_t i = 0;
+		uint32_t o = 0;
+
+		while ((i + 3) <= n) {
+			uint32_t v = ((uint32_t)data[i] << 16)
+					| ((uint32_t)data[i + 1] << 8)
+					| (uint32_t)data[i + 2];
+			out[o++] = BASE64_CHARS[(v >> 18) & 0x3f];
+			out[o++] = BASE64_CHARS[(v >> 12) & 0x3f];
+			out[o++] = BASE64_CHARS[(v >> 6) & 0x3f];
+			out[o++] = BASE64_CHARS[v & 0x3f];
+			i += 3;
+		}
+
+		// 1 or 2 leftover bytes - only possible on the final chunk since
+		// PREVIEW_CHUNK_IN is a multiple of 3
+		if (i < n) {
+			uint32_t v = (uint32_t)data[i] << 16;
+			if ((i + 1) < n) {
+				v |= (uint32_t)data[i + 1] << 8;
+			}
+			out[o++] = BASE64_CHARS[(v >> 18) & 0x3f];
+			out[o++] = BASE64_CHARS[(v >> 12) & 0x3f];
+			out[o++] = ((i + 1) < n) ? BASE64_CHARS[(v >> 6) & 0x3f] : '=';
+			out[o++] = '=';
+		}
+
+		out[o] = '\0';
+		xprintf("%s", out);
+
+		data += n;
+		length -= n;
+	}
+}
+
+void preview_sendFrame(void) {
+	uint32_t jpegLength = 0;
+	uint32_t jpegBuffer = 0;
+
+	if (previewMode == PREVIEW_OFF) {
+		return;
+	}
+
+	// Same sequence as prepareJpegFile(): hardware encoder JPEG, replaced
+	// by the WB-corrected sw_jpeg output if the correction ran
+	cisdp_get_jpginfo(&jpegLength, &jpegBuffer);
+	img_correct_get_jpeg(&jpegLength, &jpegBuffer);
+
+	if ((jpegBuffer == 0) || (jpegLength < 4) || (jpegLength > PREVIEW_MAX_JPEG_BYTES)) {
+		xprintf("Preview: implausible JPEG (addr 0x%08x length %d) - frame skipped\n",
+				jpegBuffer, jpegLength);
+		return;
+	}
+
+	SCB_InvalidateDCache_by_Addr((void *)jpegBuffer, jpegLength);
+
+	frameCount++;
+
+	xprintf("\r{\"type\": 1, \"name\": \"INVOKE\", \"code\": 0, \"data\": {\"count\": %d, "
+			"\"resolution\": [%d, %d], \"boxes\": [], \"image\": \"",
+			(int)frameCount,
+			(int)app_get_raw_width(), (int)app_get_raw_height());
+
+	sendBase64((const uint8_t *)jpegBuffer, jpegLength);
+
+	xprintf("\"}}\n");
+}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.h
@@ -1,0 +1,56 @@
+/*
+ * preview.h
+ *
+ * Live image preview over the console UART, for bench tuning of camera
+ * settings (white balance, exposure, focus, flash) while watching the
+ * effect on the picture. See _Documentation/live_preview.md
+ *
+ * Enable with the 'preview' CLI command, then start frames flowing with
+ * e.g. 'capture 1000 0'. Every captured frame is emitted on the console
+ * UART as one JSON line with the JPEG as base64. View with
+ * _Tools/live_view.py (recommended - keeps the CLI usable for
+ * camreg/vcm/setop while watching) or the Himax AI web toolkit.
+ */
+
+#ifndef PREVIEW_H_
+#define PREVIEW_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+	PREVIEW_OFF = 0,			// no streaming (normal operation)
+	PREVIEW_STREAM = 1,			// stream frames; skip SD card saves
+	PREVIEW_STREAM_AND_SAVE = 2	// stream frames; save to SD as normal
+} PREVIEW_MODE_E;
+
+/**
+ * Set the preview mode. Takes effect from the next captured frame.
+ */
+void preview_setMode(PREVIEW_MODE_E mode);
+
+PREVIEW_MODE_E preview_getMode(void);
+
+/**
+ * True when frames should be streamed (mode 1 or 2).
+ */
+bool preview_isActive(void);
+
+/**
+ * True when preview wants the SD file save skipped (mode 1).
+ */
+bool preview_skipsFileSave(void);
+
+/**
+ * Emit the JPEG of the capture just completed as one JSON line on the
+ * console UART. Call from the image task once the frame is ready - after
+ * img_correct_process() has run, so the streamed image is the same one
+ * prepareJpegFile() would save (WB-corrected sw_jpeg output when the
+ * correction ran, otherwise the hardware encoder output).
+ *
+ * Blocks the calling task for the duration of the UART write
+ * (a VGA JPEG takes roughly 300-600 ms at 921600 baud).
+ */
+void preview_sendFrame(void);
+
+#endif /* PREVIEW_H_ */

--- a/REVIEW_PR140.md
+++ b/REVIEW_PR140.md
@@ -1,0 +1,43 @@
+# PR #140: RP3 image quality: live preview, auto-exposure, auto white balance + colour pipeline
+
+> Offline copy of the pull-request description (https://github.com/wildlifeai/Seeed_Grove_Vision_AI_Module_V2/pull/140). The canonical discussion lives on GitHub; this file exists so the summary is readable from a clone without internet access.
+
+Stacks on #139 (which stacks on #138) — merge chronologically: #138 → #139 → this. GitHub will retarget this PR to `dev` when #139 merges.
+
+## What this does
+
+Fixes the RP3 (IMX708) image quality end to end. The camera now adapts itself per capture with no manual tuning — validated on the bench against phone reference photos of the same scene.
+
+### 1. Live preview over the console UART (`preview.c`, `_Tools/live_view.py`)
+New `preview <0|1|2>` CLI command streams each captured frame as base64 JPEG in the Himax/SSCMA INVOKE framing (~1 fps VGA @ 921600). The Python viewer displays the stream **and keeps the CLI usable**, so `camreg`/`vcm`/`setop` changes are visible one frame later — this is the tuning loop that made everything below measurable. `_Tools/tune_stats.py` scores frames against reference photos.
+
+### 2. Highlight-metered auto-exposure (`ae.c`, op29/op30)
+The IMX708 had one hardcoded exposure register and no AE at all. The new loop measures each frame's Y-plane (32-bin histogram) and steps exposure (8–5000 lines) then analog gain (to 16×) so the **bright quartile** lands just below white — mean metering drags high-key scenes to grey. Damped, deadbanded, 3 steps/wake for battery (unbounded during preview). Bench: converges in 3–5 frames, both directions (dark room ↔ daylight).
+
+### 3. Auto white balance + full colour pipeline (`img_correct.c`, op31)
+Fixed WB gains can't track the illuminant (indoor-calibrated gains left daylight at G/R 1.37 — the long-standing green tinge). op31=1 (default) measures each frame with a warmth-biased grey-world estimator; flash-lit/too-dark frames fall back to manual op27/28. The correction pass now mirrors the Raspberry Pi ISP order using libcamera's imx708.json calibration: **black level (16) → WB gains → 4640 K CCM → gamma LUT**.
+
+## Measured results (same scene, phone reference vs before/after)
+
+| | G/R bright-quartile | Notes |
+|---|---|---|
+| Phone reference | 0.939 | target rendering |
+| Before (fixed gains, daylight) | **1.372** | the green tinge |
+| After (auto, full pipeline) | **0.97–1.01** | white paper renders white, colours correct |
+
+Also fixes: capture frame-timeout retries now dwell progressively (100–500 ms, 5 retries) before sensor restart — instant back-to-back restarts of the marginal MIPI bring-up were observed failing where a delayed restart succeeds.
+
+## Docs
+- `_Documentation/live_preview.md` — preview usage, protocol, known quirks (0 ms capture interval wedges the IMX708 datapath; cold-boot first-capture timeouts self-heal)
+- `_Documentation/rp3-image-quality-plan.md` — the measured plan, sweep data, and imx708.json reference values
+- `Operational_Parameters.md`, `MANIFEST/config_file.md`, `CONFIG.TXT` — ops 29–31
+
+## Known follow-ups (documented, out of scope)
+- Warm/watchdog-reboot sensor bring-up remains flaky (cold boots and DPD wakes are fine; mainly affects bench flash workflows)
+- MKL62BA `aiProcessor.h` op-param mirror for the app (ops 29–31)
+- CCT-switched CCM blending and lens shading (plan Phase C3/C4)
+
+## Test
+Flash, then: `py _Tools\live_view.py --port <console COM>` → power-cycle the device → live video appears; type `setop 30 <n>` / `setop 31 <0|1|2>` and watch the effect next frame.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/_Documentation/Operational_Parameters.md
+++ b/_Documentation/Operational_Parameters.md
@@ -179,6 +179,9 @@ Those comments preceding the first index/value pair are preserved when the file 
 |    26 | OP_PARAMETER_SLOT_SWITCH 				| 0             | Automatic light-based camera image switching: 0 = off (manual `switchslot` only), 1 = automatic - after each AE light check, if the dark/bright decision (op25) wants the other camera variant and the other slot holds it, the device switches boot slot and reboots at the next sleep. See `camera_switch.c`. Note: the light decision is computed when the flash is in AE mode (op13) **or** op26 = 1, so auto-switching works even with the flash off |
 |    27 | OP_PARAMETER_WB_RED_GAIN 				| 286           | Software white-balance RED gain, Q8.8 (256 = 1.0x, 0 = correction off). RP3 colour camera only - see `img_correct.c` and [RP3_white_balance_reencode_issue.md](RP3_white_balance_reencode_issue.md) |
 |    28 | OP_PARAMETER_WB_BLUE_GAIN 				| 326           | Software white-balance BLUE gain, Q8.8 (256 = 1.0x, 0 = correction off). RP3 colour camera only |
+|    29 | OP_PARAMETER_CAM_AE_ENABLE 			| 1             | RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. Highlight-metered loop steps sensor exposure (8-5000 lines) then analog gain (to 16x) toward the target - see `ae.c` |
+|    30 | OP_PARAMETER_CAM_AE_TARGET 			| 110           | Auto-exposure target: raw bright-quartile (p75) luma, 0-250 (0 = built-in default 95). Bright parts of the scene render just below white after the tone curve |
+|    31 | OP_PARAMETER_CAM_WB_MODE 				| 1             | RP camera white balance: 0 = off (hardware JPEG), 1 = auto (warmth-biased grey-world measured per frame), 2 = manual op27/op28. Auto falls back to manual for flash-lit or too-dark frames - see `img_correct.c` |
 
 
 ## Syncronisation with BLE Processor Code

--- a/_Documentation/live_preview.md
+++ b/_Documentation/live_preview.md
@@ -1,0 +1,105 @@
+# Live Preview - streaming WW500 images to a PC for camera tuning
+#### Claude - 10 July 2026 (branch `feat/uart-live-preview`)
+
+Answers the problem statement in `Sensecraft.md`: a live stream of video from
+the WW500 onto a laptop so image quality (RP3 white balance, auto-exposure,
+focus, LED flash timing) can be adjusted dynamically and the effect seen
+immediately.
+
+The stream shows the **same JPEG the firmware would save to SD** - i.e. after
+the software white-balance correction (`img_correct.c`, op27/op28) and
+`sw_jpeg` re-encode - so what you tune is what the camera traps will record.
+This is the key difference from flashing the Himax `tflm_fd_fm` demo, which
+streams Himax's own sensor init instead.
+
+## How it works
+
+* New CLI command **`preview <mode>`** (`preview.c` in `ww500_md`):
+  * `0` - off (normal operation)
+  * `1` - stream every captured frame over the console UART, **skip SD saves**
+  * `2` - stream **and** save to SD as normal
+* Frames are only produced by captures, so streaming is driven with the
+  existing `capture <n> <interval_ms>` command, e.g. `capture 1000 0`.
+* Each frame goes out as one JSON line, the same "INVOKE" framing the
+  Himax/SSCMA scenario apps use (`send_result.cpp`), so the
+  [Himax AI web toolkit](https://github.com/HimaxWiseEyePlus/Seeed_Grove_Vision_AI_Module_V2/releases/download/v1.1/Himax_AI_web_toolkit.zip)
+  can also display it:
+
+```
+{"type": 1, "name": "INVOKE", "code": 0, "data": {"count": 12,
+ "resolution": [640, 480], "boxes": [], "image": "<base64 JPEG>"}}
+```
+
+* AE-light-check wakes are not streamed.
+* Throughput at 921600 baud (~92 KB/s): a VGA JPEG of 25-50 KB costs
+  ~0.4-0.7 s plus capture/NN time, so expect **~1.5-2.5 fps**. Setting the
+  FTDI latency timer to 1 ms helps a little (see `FTDI_Cable_Speed.md`).
+
+## The viewer: `_Tools/live_view.py`
+
+```
+py _Tools\live_view.py            # defaults COM14, 921600
+```
+
+Shows the live image plus a console log pane, a command box and quick-command
+buttons, so `setop 27 ...`, `setop 28 ...`, `vcm ...`, `camreg ...` can be
+sent **while watching**. "Start stream" sends `preview 1` + `capture 1000 0`
+and automatically re-arms the capture burst when it runs out; "Stop stream"
+sends `preview 0`. "Save frame" writes the last JPEG to disk for A/B records.
+
+Close TeraTerm first - Windows COM ports are exclusive.
+
+## Bench session recipe
+
+```
+setop 8 600000        # 10 min before DPD, so the device stays awake between bursts
+preview 1             # stream, don't wear out the SD card
+capture 1000 0        # frames start flowing
+setop 27 286          # ...adjust WB red gain while watching...
+setop 28 326          # ...adjust WB blue gain...
+vcm 512               # ...focus (RP3)...
+camreg w 0x0202 0x03e8   # ...exposure etc. (staged writes - see camreg help)
+preview 0             # stop streaming
+```
+
+Notes:
+
+* The viewer is self-arming: on connect it probes with `ver`; if the device is
+  asleep, power-cycle it and the viewer catches the boot, types the keep-awake
+  immediately (the device enters DPD ~4 s after an idle cold boot), waits for
+  "Image sensor and data path initialised" plus a settle delay, then arms
+  `preview 1` and the capture burst - every step echo-verified with retries.
+* **Do not use a 0 ms capture interval with the RP3** - `capture N 0` wedges
+  the IMX708 datapath (endless frame timeouts / sensor restarts). 500 ms is
+  reliable; the viewer uses `capture 1000 500` (~1 fps net).
+* **The first capture sequence after a cold boot often frame-times-out**
+  (`>>>> Frame timed out - restarting sensor`) even when started well after
+  camera init. Later sequences work; the viewer just re-arms every 8 s until
+  frames flow, which typically takes 30-90 s after a cold boot. Root cause in
+  the RP3 cold-boot sensor bring-up - worth a firmware look someday.
+* The console UART receive path has a 1-character buffer, so the viewer sends
+  commands one character at a time in the quiet window after each frame. If a
+  command echo looks garbled in the log pane, send it again.
+* An occasional frame is corrupted when another firmware print (e.g. the
+  fatfs task) lands inside the frame line. The viewer counts it as "dropped"
+  and skips it. This is accepted for a bench tool.
+* If frames stop because the capture burst (max 1000) finished, the viewer
+  re-arms automatically; from a bare terminal just repeat `capture 1000 0`.
+* `preview 1` skips SD saves only while preview is on. If you stop preview
+  mid-burst and want no files written, also set `setop 18 8`
+  (TEST_BIT_SKIP_FILE_CREATION) for the session, and `setop 18 0` after.
+
+## Files changed (this branch)
+
+* `EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c` / `.h` - new: frame
+  emission (chunked base64, no frame-sized buffer) and mode state.
+* `EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c` - hook in
+  `APP_MSG_IMAGETASK_FRAME_READY`: runs the WB correction in the skip-save
+  path when previewing, then `preview_sendFrame()`; `preview 1` joins the
+  skip-file-save condition.
+* `EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c` - the `preview`
+  command.
+* `_Tools/live_view.py` - new: PC viewer + tuning console.
+
+Build as usual (`_Tools/build_ww500.sh`, or CI). Works for both camera
+variants; on HM0360 builds the WB correction is simply not compiled in.

--- a/_Documentation/rp3-image-quality-plan.md
+++ b/_Documentation/rp3-image-quality-plan.md
@@ -1,0 +1,160 @@
+# RP3 (IMX708) Image Quality Plan — kill the green tinge, match the phone
+
+#### Claude - 10 July 2026 (branch `feat/uart-live-preview`)
+
+**Goal:** WW500 RP3 photos that look like the mobile-phone reference shots in
+`C:\Users\ww\rsp3vshm0360\reference photo\` (PXL_20260710_*.jpg): neutral-to-
+slightly-warm colour, full tonal range, correct exposure.
+
+This plan supersedes the colour part of `camera-field-tuning-roadmap.md`
+Phase 0/1 with what we have learned since, and it assumes the **live preview
+loop** (`preview` firmware command + `_Tools/live_view.py`, this branch) as
+the iteration tool — settings changes are now visible in ~1 s instead of a
+20-60 s BLE capture/download cycle.
+
+---
+
+## 1. Where we actually are (measured 10 Jul 2026)
+
+Channel statistics (`_Tools/tune_stats.py`, bright-quartile = paper/wall):
+
+| Image | G/R bright | G/B bright | luma mean | luma p5-p95 |
+|---|---|---|---|---|
+| Phone reference (x2 shots) | **0.94-0.95** | **1.06** | 115-119 | 34 → 225 |
+| RP3 today (op27=286/op28=326 active) | **1.13-1.16** | **1.10-1.16** | 69 | 61 → 80 |
+
+Three separate problems, in order of visual impact:
+
+1. **No auto-exposure at all.** Exposure is one hardcoded write
+   (`0x0202 = 0x0940` lines, `IMX708_exposure_setting`); analog gain
+   (`0x0204`) is never adjusted. Indoors the image is dim (luma 69) and
+   nearly flat (19 luma levels of range vs the phone's ~190).
+2. **White balance is a single fixed gain pair** (op27/op28, software,
+   applied in `img_correct.c`). It was calibrated once, under one light.
+   Under today's light the image is still green (G/R 1.13 vs target 0.94).
+   Fixed gains cannot track the illuminant; the phone's AWB does.
+3. **No colour-correction matrix, no gamma.** Even with grey neutral, the
+   Bayer channel crosstalk is uncorrected (desaturated, hue-shifted colours)
+   and the tone curve is linear (flat, murky look). The Raspberry Pi ISP
+   applies both; we apply neither. Likely also **uncorrected black level**
+   (IMX708 pedestal = 4096/65536 ≈ 16/255) which lifts and tints shadows.
+
+Facts already settled (do not re-litigate):
+
+* **In-sensor per-channel digital gains (0x0210/0x0212) do nothing** —
+  bench-verified 0% change (`RP3_white_balance_reencode_issue.md` §1).
+  White balance must stay in software. (Roadmap test 0.1 = FAIL, fallback
+  built.)
+* The software pipeline exists and works: `img_correct.c` does
+  YUV→RGB→per-channel gain→YUV + `sw_jpeg.c` re-encode, ~230 ms/VGA frame,
+  runs on both the save path and the live preview path.
+* Hardware JPEG re-encode after correction is a dead end (bus lock, ibid.).
+* `camreg` staged registers (`0:/RPV3_EX.BIN`) persist across DPD/reboot and
+  are applied after the init tables — the sweep mechanism for everything
+  below (`camera-phase0-bench-runbook.md`).
+* Two capture quirks (this branch's bench work): `capture N 0` wedges the
+  IMX708 datapath (use ≥500 ms interval); the first capture sequence after a
+  cold boot frame-times-out and self-heals on later sequences.
+
+---
+
+## 2. Reference data to reuse (don't re-derive)
+
+Raspberry Pi's calibrated tuning for this exact sensor+lens —
+`libcamera/src/ipa/rpi/vc4/data/imx708.json`:
+
+* **Black level:** 4096 (16-bit) → subtract ≈16 (8-bit) before gains/CCM.
+* **CCMs by colour temperature** (rows sum to 1.0, applied after WB):
+  * 2964 K: `[ 1.721 -0.460 -0.262 | -0.300  1.569 -0.269 |  0.151 -1.133  1.982 ]`
+  * 4640 K: `[ 1.530 -0.352 -0.178 | -0.283  1.671 -0.388 |  0.017 -0.572  1.555 ]`
+  * 7590 K: `[ 1.414 -0.211 -0.203 | -0.176  1.717 -0.541 |  0.013 -0.631  1.618 ]`
+* **AWB CT curve** (r-vs-b chrominance per CCT, 2498 K → 7433 K) — for
+  sanity-clamping grey-world results and for building Daylight/Tungsten
+  presets.
+* **Gamma curve** with strong shadow lift (16-bit: 1024→5040, 4096→15312,
+  16384→40642) — the "photographic" look our linear output lacks.
+
+Target numbers (from the phone reference): bright-quartile **G/R 0.92-1.02**,
+**G/B 0.98-1.10**, luma mean **105-130**, p95 **≥ 210** without clipping.
+
+---
+
+## 3. The plan
+
+### Phase A — Exposure first (bench sweeps today, then a minimal AE loop)
+
+WB gains computed on an underexposed frame are skewed (pedestal dominates),
+so exposure comes first.
+
+| # | Step | How | Done when |
+|---|---|---|---|
+| A1 | Exposure + gain sweep on the drawing scene | Live viewer running; `camreg 0202/0203` (lines) and `camreg 0204/0205` (analog gain) per runbook test 0.4 — result visible per-frame in the window; `Save frame` + `tune_stats.py` for numbers | Table of luma vs exposure/gain; usable ranges + frame-length clamp recorded |
+| A2 | Pick bench/day defaults | From A1, luma mean 105-130 on the bench scene | Values staged in `RPV3_EX.BIN` and written into `IMX708_exposure_setting` defaults |
+| A3 | **Minimal AE loop in firmware** | After `FRAME_READY`, mean-luma of the Y plane (already in `demosbuf`, ~1 ms subsampled); step `0x0202` (and gain above a threshold) toward target; clamp; 2-3 iterations per wake, continuous in preview mode. New op-params: AE target luma, max gain, AE enable. (Roadmap Phase 4 item, promoted — it is the biggest visible win.) | Live view converges to target luma in ≤3 frames under bench/day/dusk light; field captures well-exposed |
+
+Effort: sweeps ~half a bench day (live loop makes them minutes each); AE loop
+~1 day firmware + bench validation.
+
+### Phase B — Auto white balance (grey-world in the existing software path)
+
+| # | Step | How | Done when |
+|---|---|---|---|
+| B1 | Confirm target with the reference | `tune_stats.py` on phone shots vs saved RP3 frames of the same scene | Written acceptance band (see §2) |
+| B2 | **Grey-world AWB** in `img_correct.c` | During the existing per-pixel pass (or a subsampled pre-pass) accumulate R/G/B sums; gains = G̅/R̅, G̅/B̅ × warmth bias (~0.95 on R to match the phone's rendering); clamp via the imx708.json CT curve endpoints (≈[0.9, 2.2]); IIR-smooth across preview frames. op27/op28 (0 = auto) become manual overrides. Subtract black level (≈16) before the stats and the gains. | Grey card and drawing neutral under bench light, window daylight, and dusk without touching anything |
+| B3 | IR-night bypass | When the IR flash fired (`ledFlash` state already feeds EXIF), skip AWB/CCM — IR frames are not colour | Night captures unchanged |
+| B4 | Validate across lights + persist | Live viewer A/B vs phone shots; defaults persisted | Acceptance band met in all bench lighting |
+
+Effort: ~1 day firmware + half a day validation.
+
+### Phase C — Colour matrix + tone curve ("looks like a photo")
+
+| # | Step | How | Done when |
+|---|---|---|---|
+| C1 | Apply the 4640 K CCM after WB | Integer Q8.8 3×3 in the same RGB pass; clamp; rows renormalised | Colours visibly saturate/correct on the drawing (markers match the phone shot) |
+| C2 | Gamma LUT | 256-entry LUT from the imx708.json contrast curve, applied per channel after CCM | Shadows open up; luma histogram spreads toward the phone's 34→225 |
+| C3 | CCT-switched CCM (optional) | Estimate CCT from the AWB gains (CT curve inverse); blend 2964 K/4640 K/7590 K matrices | Only if C1's fixed matrix visibly fails under tungsten or deep shade |
+| C4 | Lens shading (assess only) | Check corners vs centre on a uniform target; imx708.json ALSC tables exist but are heavy | Decision recorded: needed or not |
+
+Budget: pipeline currently 230 ms/frame; CCM+LUT adds roughly 100-200 ms —
+fine at ~1 fps preview and one capture per field wake.
+Effort: 1-2 days including A/B tuning.
+
+### Phase D — Productize (folds back into the existing roadmap)
+
+* Promote validated exposure/AE/AWB/CCM defaults into the init tables and
+  op-param defaults; keep `camreg`/`RPV3_EX.BIN` for field experiments.
+* App UI = roadmap Phase 2 unchanged, except 2.4's "Fix colour from this
+  scene" becomes trivial: the firmware already computes grey-world gains —
+  the app just toggles auto/manual.
+* EXIF MakerNote already records WB gains + flash per photo (traceability).
+
+### Phase E — Capture-path quirks (fix opportunistically)
+
+* Cold-boot first-capture frame timeouts: add a settling delay or one
+  throwaway frame after MIPI start before the first real capture.
+* `capture N 0` datapath wedge: enforce a minimum interval in `prvCapture`.
+
+---
+
+## 4. Measurement harness & bench protocol
+
+1. `py _Tools\live_view.py --port COM13` (self-arming; power-cycle the WW500
+   if it is asleep). Keep the drawing + a grey/white card in frame; phone
+   reference shots of the same scene under the same light.
+2. Change a setting (`camreg …`, `setop 27/28 …`) in the command box; effect
+   visible next frame. `Save frame` for the record.
+3. `py _Tools\tune_stats.py "saved.jpg" "reference.jpg"` — compare
+   bright-quartile G/R, G/B and luma percentiles against the acceptance band.
+4. A phase is done when its "Done when" numbers hold under bench light,
+   window daylight, and dusk, and the frames look right next to the phone
+   shots.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|---|---|
+| CPU cost of AWB+CCM+gamma per frame | All integer/LUT in the existing pass; budget ≤500 ms/frame; measured each step |
+| Grey-world fails on colour-dominant scenes (all-green bush) | Clamp gains to the CT curve band; IIR smoothing; manual override op-params stay |
+| HW5x5 output may already bake in some processing (unknown gamma?) | A1 sweeps establish the sensor→YUV transfer empirically before we shape it |
+| AE hunting / flicker under mains light | Damped steps, ±tolerance band around target luma, max 3 iterations per wake |
+| uint16 op-params | Gains stay Q8.8 (fits); AE target luma 0-255 (fits) |

--- a/_Tools/live_view.py
+++ b/_Tools/live_view.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Live camera preview + tuning console for the WW500.
+
+Companion to the firmware 'preview' CLI command (branch feat/uart-live-preview).
+The firmware streams each captured frame on the console UART as one JSON line:
+
+  {"type": 1, "name": "INVOKE", "code": 0, "data": {"count": N,
+   "resolution": [W, H], "boxes": [], "image": "<base64 JPEG>"}}
+
+This tool displays the frames live and keeps the CLI usable at the same time,
+so camera settings can be adjusted while watching the picture change, e.g.:
+
+    setop 27 286               WB red gain (Q8.8, 256 = 1.0x)
+    setop 28 326               WB blue gain
+    vcm 512                    focus position (RP3 only)
+    camreg w 0x0202 0x03e8     sensor register write (staged - see camreg help)
+
+It also handles the WW500's sleep habits by itself: on connect it probes the
+device with 'ver'; if there is no answer it waits for a boot banner (power-
+cycle the device, or wave at the lens if MD is armed), then immediately types
+the keep-awake (the device DPDs ~4 s after an idle cold boot), turns preview
+on and starts a capture burst - every step echo-verified with retries.
+
+Usage:
+    py live_view.py                    # defaults: COM14, 921600
+    py live_view.py --port COM13
+
+NOTES
+ - Close TeraTerm first: Windows COM ports are exclusive.
+ - The console UART receive path has a 1-character buffer re-armed by the CLI
+   task, so commands are sent one character at a time, preferably in the quiet
+   gap right after a frame arrives.
+ - An occasional frame is lost when another firmware print lands inside the
+   frame line; it is counted as 'dropped' and skipped.
+ - op8 (inactivity) is 16-bit: 60000 ms is the usable maximum. Streaming
+   resets the timer continuously, so the device stays awake while you tune.
+   Restore field behaviour when done: setop 8 1000
+"""
+
+import argparse
+import base64
+import io
+import json
+import queue
+import re
+import sys
+import threading
+import time
+from collections import deque
+from datetime import datetime
+
+import serial
+import tkinter as tk
+from tkinter import scrolledtext
+from PIL import Image, ImageTk
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+FRAME_MARKER = '"name": "INVOKE"'
+FRAME_OK = "\x00FRAME"         # sentinel: step is confirmed by a decoded frame
+MAX_LINE = 512 * 1024          # a VGA frame line is ~35-70 KB; anything huge is junk
+CHAR_DELAY = 0.03              # per-character send delay (see module docstring)
+# NB: interval 0 wedges the IMX708 datapath (frame timeouts + endless sensor
+# restarts). 500 ms is reliable and still gives ~1 fps once capture,
+# WB-correct and UART streaming time are included.
+CAPTURE_CMD = "capture 1000 500"
+REARM_QUIET_S = 8.0            # re-send capture when streaming and no frame this long
+DISPLAY_MAX = (800, 600)
+SEND_RETRY_S = 3.0             # resend an unconfirmed sequence step this often
+SEND_TRIES = 8
+
+CLI_UP_RE = re.compile(r"Starting CLI Task|Enter 'help' to view")
+# Camera/datapath init is complete only here - sending a capture before this
+# collides with the init and every frame times out until the next power-cycle.
+BOOT_DONE_RE = re.compile(r"Image sensor and data path initialised")
+BOOT_SETTLE_S = 4.0            # boot-done -> arm delay (lets the boot capture finish)
+
+KEEPAWAKE_STEP = ("setop 8 60000", "Set OpParam 8 = 60000")
+
+# The arm sequence: preview mode 1 (stream, skip SD saves), then a long
+# capture burst. Each step is resent until its confirmation string appears.
+# The keep-awake goes out earlier, at CLI-up (safe before the camera init).
+ARM_SEQUENCE = [
+    ("preview 1", "Preview mode 1"),
+    (CAPTURE_CMD, FRAME_OK),
+]
+
+
+class SerialWorker(threading.Thread):
+    """Reads the console UART, splitting frames from ordinary console lines.
+
+    Outgoing commands go through a verified-send queue: each (cmd, expect)
+    step is typed one character at a time and resent until `expect` shows up
+    in the console output (or a frame arrives, for the FRAME_OK sentinel).
+    Steps with expect=None are fire-once (used for manual commands).
+    """
+
+    def __init__(self, port, baud, frame_q, log_q):
+        super().__init__(daemon=True)
+        self.frame_q = frame_q
+        self.log_q = log_q
+        self.seq = deque()          # entries: [cmd, expect, tries_left]
+        self.seq_last_send = 0.0
+        self.dropped = 0
+        self.last_frame_ts = 0.0
+        self.last_cli_up = 0.0
+        self.arm_at = None          # deferred arm time after boot-done
+        self.autoarm_enabled = True
+        self.running = True
+        self.ser = serial.Serial(port, baud, timeout=0.05)
+
+    # ---- command sending -------------------------------------------------
+
+    def send(self, cmd):
+        """Fire-once manual command (no confirmation)."""
+        self.seq.append([cmd.strip(), None, 1])
+
+    def enqueue_verified(self, steps):
+        for cmd, expect in steps:
+            self.seq.append([cmd, expect, SEND_TRIES])
+
+    def arm(self, reason):
+        if any(step[1] == FRAME_OK for step in self.seq):
+            return  # an arm sequence is already pending
+        self.log_q.put(f"[viewer] {reason} - arming preview stream")
+        self.enqueue_verified(ARM_SEQUENCE)
+
+    def _write_now(self, cmd):
+        self.log_q.put(f"> {cmd}")
+        data = cmd.encode("ascii", "replace") + b"\r\n"
+        for i in range(len(data)):
+            self.ser.write(data[i:i + 1])
+            self.ser.flush()
+            time.sleep(CHAR_DELAY)
+
+    def _pump_seq(self, force=False):
+        """Send/resend the head of the queue. Called from the reader loop
+        (when the port is quiet) and right after each frame (the safe gap)."""
+        if not self.seq:
+            return
+        now = time.monotonic()
+        if not force and (now - self.seq_last_send) < SEND_RETRY_S:
+            return
+        cmd, expect, tries = self.seq[0]
+        if expect is None:
+            self.seq.popleft()
+            self._write_now(cmd)
+            self.seq_last_send = time.monotonic()
+            return
+        if tries <= 0:
+            self.log_q.put(f"[viewer] no confirmation for '{cmd}' - giving up "
+                           f"(power-cycle the device and it will re-arm)")
+            self.seq.popleft()
+            return
+        self.seq[0][2] = tries - 1
+        self._write_now(cmd)
+        self.seq_last_send = time.monotonic()
+
+    def _confirm(self, line):
+        if self.seq:
+            cmd, expect, _tries = self.seq[0]
+            if expect and expect != FRAME_OK and expect in line:
+                self.log_q.put(f"[viewer] confirmed: {cmd}")
+                self.seq.popleft()
+                self.seq_last_send = 0.0  # next step goes out immediately
+
+    def _confirm_frame(self):
+        if self.seq and self.seq[0][1] == FRAME_OK:
+            self.log_q.put(f"[viewer] confirmed: {self.seq[0][0]} (frames flowing)")
+            self.seq.popleft()
+
+    # ---- receive path ----------------------------------------------------
+
+    def _handle_line(self, raw):
+        line = ANSI_RE.sub("", raw.decode("utf-8", "replace")).strip("\r\n \t")
+        if not line:
+            return
+        if FRAME_MARKER in line:
+            start = line.find('{"type"')
+            if start >= 0:
+                try:
+                    msg = json.loads(line[start:])
+                    data = msg["data"]
+                    jpeg = base64.b64decode(data["image"], validate=True)
+                    self.last_frame_ts = time.monotonic()
+                    count = data.get("count", 0)
+                    if count <= 3 or count % 20 == 0:
+                        self.log_q.put(f"[frame] #{count} {len(jpeg)} bytes")
+                    self._confirm_frame()
+                    self.frame_q.put((data.get("count", 0),
+                                      data.get("resolution", [0, 0]), jpeg))
+                    # frame boundary = the quiet window: send any pending step
+                    self._pump_seq(force=True)
+                    return
+                except (ValueError, KeyError, TypeError):
+                    self.dropped += 1
+                    self.log_q.put(f"[viewer] dropped corrupt frame line "
+                                   f"({len(line)} chars, total dropped {self.dropped})")
+                    return
+        self._confirm(line)
+        now = time.monotonic()
+        if (self.autoarm_enabled and CLI_UP_RE.search(line)
+                and now - self.last_frame_ts > 10 and now - self.last_cli_up > 10):
+            # Fresh boot: drop any stale queued steps, keep the device awake
+            # right away, and defer preview/capture until the camera init is
+            # done (see BOOT_DONE_RE).
+            self.last_cli_up = now
+            self.arm_at = None
+            self.seq.clear()
+            self.log_q.put("[viewer] boot detected - keeping device awake, "
+                           "waiting for camera init before arming")
+            self.enqueue_verified([KEEPAWAKE_STEP])
+        if self.autoarm_enabled and BOOT_DONE_RE.search(line):
+            self.arm_at = now + BOOT_SETTLE_S
+            self.log_q.put(f"[viewer] camera init done - arming in {BOOT_SETTLE_S:.0f} s")
+        self.log_q.put(line)
+
+    def run(self):
+        # Probe: if the device is already awake this confirms and arms;
+        # if it is asleep the probe goes nowhere and the boot catcher arms.
+        self.enqueue_verified([("ver", "WW500"), KEEPAWAKE_STEP])
+        self.arm("connected")
+
+        buf = bytearray()
+        while self.running:
+            try:
+                chunk = self.ser.read(4096)
+            except serial.SerialException as e:
+                self.log_q.put(f"[viewer] serial error: {e}")
+                break
+            if chunk:
+                buf.extend(chunk)
+                while True:
+                    nl = buf.find(b"\n")
+                    if nl < 0:
+                        break
+                    line = bytes(buf[:nl])
+                    del buf[:nl + 1]
+                    self._handle_line(line)
+                if len(buf) > MAX_LINE:
+                    buf.clear()
+                    self.dropped += 1
+            # deferred arm once the boot has settled
+            if self.arm_at is not None and time.monotonic() >= self.arm_at:
+                self.arm_at = None
+                self.arm("boot settled")
+            # device quiet (asleep, booting, or between frames): safe to send
+            if time.monotonic() - self.last_frame_ts > 3.0:
+                self._pump_seq()
+        try:
+            self.ser.close()
+        except serial.SerialException:
+            pass
+
+    def stop(self):
+        self.running = False
+
+
+class Viewer:
+    def __init__(self, root, worker):
+        self.root = root
+        self.worker = worker
+        self.frame_q = worker.frame_q
+        self.log_q = worker.log_q
+        self.streaming = True   # auto-armed on connect
+        self.last_jpeg = None
+        self.last_rearm = time.monotonic()
+        self.frame_times = deque(maxlen=10)
+        self.photo = None  # keep a reference or tkinter drops the image
+
+        root.title(f"WW500 Live View - {worker.ser.port} @ {worker.ser.baudrate}")
+
+        main = tk.Frame(root)
+        main.pack(fill=tk.BOTH, expand=True)
+
+        self.image_label = tk.Label(main,
+                                    text="waiting for frames...\n\n"
+                                         "if nothing appears in ~15 s the device is asleep:\n"
+                                         "power-cycle it and this window will catch the boot",
+                                    width=80, height=24, bg="#202020", fg="#a0a0a0")
+        self.image_label.grid(row=0, column=0, padx=4, pady=4, sticky="nsew")
+
+        side = tk.Frame(main)
+        side.grid(row=0, column=1, padx=4, pady=4, sticky="ns")
+
+        self.status = tk.Label(side, justify=tk.LEFT, anchor="w", font=("Consolas", 10))
+        self.status.pack(fill=tk.X, pady=(0, 8))
+        self._set_status(None)
+
+        tk.Button(side, text="Start stream", command=self.start_stream).pack(fill=tk.X)
+        tk.Button(side, text="Stop stream", command=self.stop_stream).pack(fill=tk.X, pady=(4, 0))
+        tk.Button(side, text="Save frame", command=self.save_frame).pack(fill=tk.X, pady=(4, 12))
+
+        tk.Label(side, text="Command:").pack(anchor="w")
+        self.cmd_entry = tk.Entry(side, width=28, font=("Consolas", 10))
+        self.cmd_entry.pack(fill=tk.X)
+        self.cmd_entry.bind("<Return>", self.send_command)
+        tk.Button(side, text="Send", command=self.send_command).pack(fill=tk.X, pady=(4, 0))
+
+        tk.Label(side, text="Quick commands:").pack(anchor="w", pady=(12, 0))
+        for cmd in ("getop 27", "setop 27 286", "setop 28 326",
+                    "vcm 512", "status", "setop 8 1000"):
+            tk.Button(side, text=cmd, font=("Consolas", 9),
+                      command=lambda c=cmd: self.worker.send(c)).pack(fill=tk.X, pady=1)
+
+        self.log = scrolledtext.ScrolledText(root, height=12, font=("Consolas", 9),
+                                             state=tk.DISABLED, wrap=tk.NONE)
+        self.log.pack(fill=tk.BOTH, expand=False, padx=4, pady=(0, 4))
+
+        main.grid_columnconfigure(0, weight=1)
+        main.grid_rowconfigure(0, weight=1)
+
+        root.protocol("WM_DELETE_WINDOW", self.close)
+        root.after(30, self.poll)
+
+    def _set_status(self, info):
+        if info is None:
+            self.status.config(text="frames    -\nsize      -\nfps       -\ndropped   0")
+            return
+        count, res, kbytes, fps = info
+        self.status.config(text=(f"frames    {count}\n"
+                                 f"size      {kbytes:.1f} KB  {res[0]}x{res[1]}\n"
+                                 f"fps       {fps:.2f}\n"
+                                 f"dropped   {self.worker.dropped}"))
+
+    def start_stream(self):
+        self.streaming = True
+        self.last_rearm = time.monotonic()
+        self.worker.arm("start requested")
+
+    def stop_stream(self):
+        self.streaming = False
+        self.worker.send("preview 0")
+
+    def send_command(self, _event=None):
+        cmd = self.cmd_entry.get().strip()
+        if cmd:
+            self.worker.send(cmd)
+            self.cmd_entry.delete(0, tk.END)
+
+    def save_frame(self):
+        if not self.last_jpeg:
+            self._append_log("[viewer] no frame to save yet")
+            return
+        name = datetime.now().strftime("live_%Y%m%d_%H%M%S.jpg")
+        with open(name, "wb") as f:
+            f.write(self.last_jpeg)
+        self._append_log(f"[viewer] saved {name} ({len(self.last_jpeg)} bytes)")
+
+    def _append_log(self, line):
+        print(line, flush=True)  # tee to stdout so a supervising session can watch
+        self.log.config(state=tk.NORMAL)
+        self.log.insert(tk.END, line + "\n")
+        # keep the pane bounded
+        if float(self.log.index(tk.END)) > 2000:
+            self.log.delete("1.0", "500.0")
+        self.log.see(tk.END)
+        self.log.config(state=tk.DISABLED)
+
+    def _show_frame(self, count, res, jpeg):
+        self.last_jpeg = jpeg
+        now = time.monotonic()
+        self.frame_times.append(now)
+        fps = 0.0
+        if len(self.frame_times) >= 2:
+            span = self.frame_times[-1] - self.frame_times[0]
+            if span > 0:
+                fps = (len(self.frame_times) - 1) / span
+        try:
+            img = Image.open(io.BytesIO(jpeg))
+            img.load()
+        except OSError as e:
+            self.worker.dropped += 1
+            self._append_log(f"[viewer] undecodable JPEG ({e})")
+            return
+        if img.width > DISPLAY_MAX[0] or img.height > DISPLAY_MAX[1]:
+            img.thumbnail(DISPLAY_MAX)
+        self.photo = ImageTk.PhotoImage(img)
+        self.image_label.config(image=self.photo, text="", width=img.width, height=img.height)
+        self._set_status((count, res, len(jpeg) / 1024.0, fps))
+
+    def poll(self):
+        try:
+            while True:
+                self._append_log(self.log_q.get_nowait())
+        except queue.Empty:
+            pass
+        frame = None
+        try:
+            while True:  # drain to the newest frame; show only that one
+                frame = self.frame_q.get_nowait()
+        except queue.Empty:
+            pass
+        if frame:
+            self._show_frame(*frame)
+
+        # burst of 1000 captures ran out? start another while streaming
+        now = time.monotonic()
+        if (self.streaming and self.worker.last_frame_ts > 0
+                and now - self.worker.last_frame_ts > REARM_QUIET_S
+                and now - self.last_rearm > REARM_QUIET_S
+                and not self.worker.seq):
+            self._append_log("[viewer] stream quiet - re-arming capture")
+            self.worker.enqueue_verified([(CAPTURE_CMD, FRAME_OK)])
+            self.last_rearm = now
+
+        self.root.after(30, self.poll)
+
+    def close(self):
+        try:
+            if self.streaming:
+                self.worker.send("preview 0")
+                time.sleep(1.5)  # give the command a chance to go out
+        finally:
+            self.worker.stop()
+            self.root.destroy()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--port", default="COM14")
+    ap.add_argument("--baud", type=int, default=921600)
+    args = ap.parse_args()
+
+    frame_q = queue.Queue()
+    log_q = queue.Queue()
+    try:
+        worker = SerialWorker(args.port, args.baud, frame_q, log_q)
+    except serial.SerialException as e:
+        print(f"Cannot open {args.port}: {e}", file=sys.stderr)
+        print("Is TeraTerm (or another terminal) still holding the port?", file=sys.stderr)
+        return 2
+    worker.start()
+
+    root = tk.Tk()
+    Viewer(root, worker)
+    root.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_Tools/tune_stats.py
+++ b/_Tools/tune_stats.py
@@ -1,0 +1,38 @@
+"""Channel statistics for tuning: overall + brightest-quartile (grey-world and
+white-patch estimators), for the mobile reference photos and RP3 frames."""
+import glob
+import sys
+
+import numpy as np
+from PIL import Image
+
+
+def stats(path):
+    img = Image.open(path).convert("RGB")
+    img.thumbnail((800, 800))
+    a = np.asarray(img, dtype=np.float64)
+    r, g, b = a[..., 0], a[..., 1], a[..., 2]
+    luma = 0.299 * r + 0.587 * g + 0.114 * b
+
+    def ratios(mask=None):
+        if mask is None:
+            mr, mg, mb = r.mean(), g.mean(), b.mean()
+        else:
+            mr, mg, mb = r[mask].mean(), g[mask].mean(), b[mask].mean()
+        return mr, mg, mb, mg / max(mr, 1e-6), mg / max(mb, 1e-6)
+
+    # white-patch-ish: brightest 25% of pixels by luma (paper/wall)
+    thresh = np.percentile(luma, 75)
+    bright = luma >= thresh
+
+    mr, mg, mb, gr, gb = ratios()
+    wr, wg, wb, wgr, wgb = ratios(bright)
+    print(f"{path.split(chr(92))[-1]}")
+    print(f"  overall  R={mr:6.1f} G={mg:6.1f} B={mb:6.1f}   G/R={gr:5.3f} G/B={gb:5.3f}")
+    print(f"  bright25 R={wr:6.1f} G={wg:6.1f} B={wb:6.1f}   G/R={wgr:5.3f} G/B={wgb:5.3f}")
+    print(f"  luma mean={luma.mean():5.1f}  p5={np.percentile(luma,5):5.1f}  p95={np.percentile(luma,95):5.1f}")
+
+
+for pattern in sys.argv[1:]:
+    for p in sorted(glob.glob(pattern)):
+        stats(p)


### PR DESCRIPTION
Stacks on #139 (which stacks on #138) — merge chronologically: #138 → #139 → this. GitHub will retarget this PR to `dev` when #139 merges.

## What this does

Fixes the RP3 (IMX708) image quality end to end. The camera now adapts itself per capture with no manual tuning — validated on the bench against phone reference photos of the same scene.

### 1. Live preview over the console UART (`preview.c`, `_Tools/live_view.py`)
New `preview <0|1|2>` CLI command streams each captured frame as base64 JPEG in the Himax/SSCMA INVOKE framing (~1 fps VGA @ 921600). The Python viewer displays the stream **and keeps the CLI usable**, so `camreg`/`vcm`/`setop` changes are visible one frame later — this is the tuning loop that made everything below measurable. `_Tools/tune_stats.py` scores frames against reference photos.

### 2. Highlight-metered auto-exposure (`ae.c`, op29/op30)
The IMX708 had one hardcoded exposure register and no AE at all. The new loop measures each frame's Y-plane (32-bin histogram) and steps exposure (8–5000 lines) then analog gain (to 16×) so the **bright quartile** lands just below white — mean metering drags high-key scenes to grey. Damped, deadbanded, 3 steps/wake for battery (unbounded during preview). Bench: converges in 3–5 frames, both directions (dark room ↔ daylight).

### 3. Auto white balance + full colour pipeline (`img_correct.c`, op31)
Fixed WB gains can't track the illuminant (indoor-calibrated gains left daylight at G/R 1.37 — the long-standing green tinge). op31=1 (default) measures each frame with a warmth-biased grey-world estimator; flash-lit/too-dark frames fall back to manual op27/28. The correction pass now mirrors the Raspberry Pi ISP order using libcamera's imx708.json calibration: **black level (16) → WB gains → 4640 K CCM → gamma LUT**.

## Measured results (same scene, phone reference vs before/after)

| | G/R bright-quartile | Notes |
|---|---|---|
| Phone reference | 0.939 | target rendering |
| Before (fixed gains, daylight) | **1.372** | the green tinge |
| After (auto, full pipeline) | **0.97–1.01** | white paper renders white, colours correct |

Also fixes: capture frame-timeout retries now dwell progressively (100–500 ms, 5 retries) before sensor restart — instant back-to-back restarts of the marginal MIPI bring-up were observed failing where a delayed restart succeeds.

## Docs
- `_Documentation/live_preview.md` — preview usage, protocol, known quirks (0 ms capture interval wedges the IMX708 datapath; cold-boot first-capture timeouts self-heal)
- `_Documentation/rp3-image-quality-plan.md` — the measured plan, sweep data, and imx708.json reference values
- `Operational_Parameters.md`, `MANIFEST/config_file.md`, `CONFIG.TXT` — ops 29–31

## Known follow-ups (documented, out of scope)
- Warm/watchdog-reboot sensor bring-up remains flaky (cold boots and DPD wakes are fine; mainly affects bench flash workflows)
- MKL62BA `aiProcessor.h` op-param mirror for the app (ops 29–31)
- CCT-switched CCM blending and lens shading (plan Phase C3/C4)

## Test
Flash, then: `py _Tools\live_view.py --port <console COM>` → power-cycle the device → live video appears; type `setop 30 <n>` / `setop 31 <0|1|2>` and watch the effect next frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)