### PR TITLE
feat(md): motion-detection instrumentation + live overlay + camreg sweep harness

### DIFF
--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c
@@ -130,6 +130,7 @@
 #include "xip_manager.h"
 #include "camera_switch.h"
 #include "hm0360_md.h"
+#include "hm0360_regs.h"	// ROIOUTENTRIES + MD register names for the `md` instrumentation subcommands
 
 #include "barrier.h"
 #include "cisdp_sensor.h"
@@ -663,9 +664,10 @@ static BaseType_t prvFormatCommand( char * pcWriteBuffer,
 /* Structure that defines the "md" command line command. */
 static const CLI_Command_Definition_t xMd = {
 	"md", /* The command string to type. */
-	"md <sensitivity>:\r\n Set sensitivity (values 1, 2, 3 = low, med, high; 0 = off)\r\n",
+	"md <sensitivity>:\r\n Set sensitivity (1,2,3 = low,med,high; 0 = off).\r\n"
+	" md dump | grid | read <addr> | write <addr> <val>  (MD register instrumentation, hex addr/val)\r\n",
 	prvMd, /* The function to run. */
-	1		 /* One parameter expected */
+	-1		 /* Variable parameters: 1 for sensitivity/dump/grid, 2 for read, 3 for write */
 };
 
 /* Structure that defines the "inithm0360" command line command. */
@@ -2214,36 +2216,128 @@ static BaseType_t prvEraseModel(char *pcWriteBuffer, size_t xWriteBufferLen, con
 // TODO - if we need this command while using RP camera then we need to move cisdp_sensor_set_md_sensitivity()
 #if defined(USE_HM0360)
 /**
- * Sets motion detection sensitivity:
+ * `md` command. Two roles:
  *
- * 0 = off
- * 1 = low
- * 2 = medium
- * 3 = high
+ *   md <0-3>                     set MD sensitivity (0=off,1=low,2=med,3=high)
+ *
+ *   md dump                      print the tunable MD registers to the console
+ *   md grid                      print the 16x16 motion-block grid + block count
+ *   md read  <addr>              read one HM0360 register (hex addr)
+ *   md write <addr> <val>        write one HM0360 register (hex addr + val)
+ *
+ * The subcommands are the Phase-0 register-sweep instrumentation for
+ * characterising motion presets - see doc/Motion_detection_presets.md. Writing
+ * MD registers while the sensor streams can disrupt it; sequence with `md`
+ * sensitivity / `inithm0360` as needed on the bench.
  */
 static BaseType_t prvMd(char *pcWriteBuffer, size_t xWriteBufferLen, const char *pcCommandString) {
 	const char *pcParameter;
-	BaseType_t lParameterStringLength;
-	uint16_t sensitivity;
+	BaseType_t lLen;
+	char *endptr;
 
-	/* Get parameter */
-	pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 1, &lParameterStringLength);
-	if (pcParameter != NULL) {
-		char *endptr;
-		long sensitivity_long = strtol(pcParameter, &endptr, 10);
+	pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 1, &lLen);
+	if (pcParameter == NULL) {
+		cli_append(&pcWriteBuffer, &xWriteBufferLen,
+		           "md <0-3> | dump | grid | read <addr> | write <addr> <val>");
+		return pdFALSE;
+	}
 
-		if (endptr == pcParameter || *endptr != '\0' || sensitivity_long < 0 || sensitivity_long > 3) {
-			cli_append(&pcWriteBuffer, &xWriteBufferLen, "Error: Sensitivity must be an integer between 0 and 3.");
+	/* --- Phase-0 instrumentation subcommands --- */
+	if ((lLen == 4) && (strncmp(pcParameter, "dump", 4) == 0)) {
+		hm0360_md_dumpConfig();		/* prints to console */
+		cli_append(&pcWriteBuffer, &xWriteBufferLen, "MD registers dumped to console");
+		return pdFALSE;
+	}
+
+	if ((lLen == 4) && (strncmp(pcParameter, "grid", 4) == 0)) {
+		static uint8_t roiOut[ROIOUTENTRIES];
+		static char gridBuf[160];
+		uint16_t mdBlocks = hm0360_md_getMDOutput(roiOut, ROIOUTENTRIES);
+
+		/* 16x16 grid to the console in two 128-block halves (as image_task does) */
+		hm0360_md_printGrid(roiOut, 128, gridBuf, sizeof(gridBuf));
+		xprintf("%s", gridBuf);
+		hm0360_md_printGrid(&roiOut[16], 128, gridBuf, sizeof(gridBuf));
+		xprintf("%s\n", gridBuf);
+
+		cli_append(&pcWriteBuffer, &xWriteBufferLen,
+		           "MD motion in %u blocks (16x16 grid on console)", mdBlocks);
+		return pdFALSE;
+	}
+
+	if ((lLen == 4) && (strncmp(pcParameter, "read", 4) == 0)) {
+		uint16_t addr;
+		uint8_t val;
+		pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 2, &lLen);
+		if (pcParameter == NULL) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "usage: md read <addr>  (hex, e.g. 209b)");
+			return pdFALSE;
+		}
+		addr = (uint16_t)strtol(pcParameter, &endptr, 16);
+		if (endptr == pcParameter) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "bad address");
+			return pdFALSE;
+		}
+		if (hm0360_md_readReg(addr, &val) == HX_CIS_NO_ERROR) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "reg 0x%04x = 0x%02x", addr, val);
 		}
 		else {
-			sensitivity = (uint16_t)sensitivity_long;
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "read failed (HM0360 present?)");
+		}
+		return pdFALSE;
+	}
+
+	if ((lLen == 5) && (strncmp(pcParameter, "write", 5) == 0)) {
+		uint16_t addr;
+		long lval;
+		uint8_t val, readback;
+		pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 2, &lLen);
+		if (pcParameter == NULL) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "usage: md write <addr> <val>  (hex)");
+			return pdFALSE;
+		}
+		addr = (uint16_t)strtol(pcParameter, &endptr, 16);
+		if (endptr == pcParameter) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "bad address");
+			return pdFALSE;
+		}
+		pcParameter = FreeRTOS_CLIGetParameter(pcCommandString, 3, &lLen);
+		if (pcParameter == NULL) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "usage: md write <addr> <val>  (hex)");
+			return pdFALSE;
+		}
+		lval = strtol(pcParameter, &endptr, 16);
+		if ((endptr == pcParameter) || (lval < 0) || (lval > 0xff)) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "bad value (00-ff)");
+			return pdFALSE;
+		}
+		val = (uint8_t)lval;
+		if (hm0360_md_writeReg(addr, val) == HX_CIS_NO_ERROR) {
+			readback = val;
+			hm0360_md_readReg(addr, &readback);
+			cli_append(&pcWriteBuffer, &xWriteBufferLen,
+			           "reg 0x%04x <- 0x%02x (now 0x%02x)", addr, val, readback);
+		}
+		else {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen, "write failed (HM0360 present?)");
+		}
+		return pdFALSE;
+	}
+
+	/* --- default: numeric sensitivity 0-3 (backward compatible) --- */
+	{
+		long sensitivity_long = strtol(pcParameter, &endptr, 10);
+
+		if ((endptr == pcParameter) || (*endptr != '\0') || (sensitivity_long < 0) || (sensitivity_long > 3)) {
+			cli_append(&pcWriteBuffer, &xWriteBufferLen,
+			           "Error: use 'md <0-3>' or 'md dump|grid|read <addr>|write <addr> <val>'");
+		}
+		else {
+			uint16_t sensitivity = (uint16_t)sensitivity_long;
 			cisdp_sensor_set_md_sensitivity(sensitivity);
 			fatfs_setOperationalParameter(OP_PARAMETER_MD_SENSITIVITY, sensitivity);
 			cli_append(&pcWriteBuffer, &xWriteBufferLen, "MD sensitivity set to %u", sensitivity);
 		}
-	}
-	else {
-		cli_append(&pcWriteBuffer, &xWriteBufferLen, "Error: Missing sensitivity parameter.");
 	}
 
 	return pdFALSE;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
@@ -44,3 +44,5 @@
 30 0
 # 31: RP camera white balance: 0 = off, 1 = auto, 2 = manual (op27/28).
 31 1
+# 32: RP camera resolution: 0 = 640x480, 1 = 1280x960 single JPEG (needs op14 = 0).
+32 0

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/CONFIG.TXT
@@ -46,3 +46,7 @@
 31 1
 # 32: RP camera resolution: 0 = 640x480, 1 = 1280x960 single JPEG (needs op14 = 0).
 32 0
+# 33: MD global-motion rejection: skip the capture when an MD wake shows motion in
+#     MORE than this many of the 256 grid blocks (whole-scene shift = camera knock
+#     or lighting change, not an animal). 0 disables. Try 100-180.
+33 0

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
@@ -1,5 +1,5 @@
 # Description of the CONFIG.TXT File
-#### CGP - 25 April 2026 (updated 11 July 2026: parameters 29-31 - RP camera auto-exposure and white-balance mode)
+#### CGP - 25 April 2026 (updated 11 July 2026: parameters 29-32 - RP camera auto-exposure, white-balance mode and resolution)
 
 The CONFIG.TXT file contains "Operational Parameters" for the WW500.
 
@@ -71,6 +71,7 @@ captured first.
 |    29 | OP_PARAMETER_CAM_AE_ENABLE 			| 1             | RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. Highlight-metered loop steps sensor exposure (8-5000 lines) then analog gain (to 16x) toward the target - see `ae.c` |
 |    30 | OP_PARAMETER_CAM_AE_TARGET 			| 110           | Auto-exposure target: raw bright-quartile (p75) luma, 0-250 (0 = built-in default 95). Bright parts of the scene render just below white after the tone curve |
 |    31 | OP_PARAMETER_CAM_WB_MODE 				| 1             | RP camera white balance: 0 = off (hardware JPEG), 1 = auto (warmth-biased grey-world measured per frame), 2 = manual op27/op28. Auto falls back to manual for flash-lit or too-dark frames - see `img_correct.c` |
+|    32 | OP_PARAMETER_CAM_RESOLUTION 			| 0             | RP camera capture resolution: 0 = 640x480 (normal pipeline), 1 = 1280x960 single JPEG via the CPU pipeline - requires the NN off (op14 = 0); see [hires-capture.md](hires-capture.md) |
 
 ## More Details
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/MANIFEST/config_file.md
@@ -1,5 +1,5 @@
 # Description of the CONFIG.TXT File
-#### CGP - 25 April 2026 (updated 11 July 2026: parameters 29-32 - RP camera auto-exposure, white-balance mode and resolution)
+#### CGP - 25 April 2026 (updated 13 July 2026: parameter 33 - MD global-motion rejection; 11 July 2026: parameters 29-32 - RP camera auto-exposure, white-balance mode and resolution)
 
 The CONFIG.TXT file contains "Operational Parameters" for the WW500.
 
@@ -72,6 +72,7 @@ captured first.
 |    30 | OP_PARAMETER_CAM_AE_TARGET 			| 110           | Auto-exposure target: raw bright-quartile (p75) luma, 0-250 (0 = built-in default 95). Bright parts of the scene render just below white after the tone curve |
 |    31 | OP_PARAMETER_CAM_WB_MODE 				| 1             | RP camera white balance: 0 = off (hardware JPEG), 1 = auto (warmth-biased grey-world measured per frame), 2 = manual op27/op28. Auto falls back to manual for flash-lit or too-dark frames - see `img_correct.c` |
 |    32 | OP_PARAMETER_CAM_RESOLUTION 			| 0             | RP camera capture resolution: 0 = 640x480 (normal pipeline), 1 = 1280x960 single JPEG via the CPU pipeline - requires the NN off (op14 = 0); see [hires-capture.md](hires-capture.md) |
+|    33 | OP_PARAMETER_MD_BLOCK_NUM_MAX 		| 0             | Global-motion rejection: skip the capture when an MD wake shows motion in MORE than this many of the 256 grid blocks. A whole-scene shift (camera knock/pan, lighting change) lights most of the grid; an animal lights a small local cluster. 0 disables; try 100-180. Complements the sensor's MD_BLOCK_NUM_TH, which is the *minimum* blocks needed to trigger. Checked at wake, before the capture starts - the wake itself cannot be prevented, but the false capture/save/upload is |
 
 ## More Details
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.c
@@ -103,17 +103,24 @@ static void writeReg16(uint16_t regH, uint16_t value) {
 }
 
 bool ae_process(uint32_t yAddr, uint16_t w, uint16_t h) {
+	if ((yAddr == 0) || (w == 0) || (h == 0)) {
+		return false;
+	}
+	if (fatfs_getOperationalParameter(OP_PARAMETER_CAM_AE_ENABLE) == 0) {
+		return false;	// skip the measurement cost when AE is off
+	}
+	return ae_process_measured(brightLuma(yAddr, w, h));
+}
+
+bool ae_process_measured(uint32_t p75Raw) {
+	uint32_t measured = p75Raw;
+
 	if (fatfs_getOperationalParameter(OP_PARAMETER_CAM_AE_ENABLE) == 0) {
 		return false;
 	}
 	if ((stepsThisWake >= AE_MAX_STEPS_PER_WAKE) && !preview_isActive()) {
 		return false;
 	}
-	if ((yAddr == 0) || (w == 0) || (h == 0)) {
-		return false;
-	}
-
-	uint32_t measured = brightLuma(yAddr, w, h);
 
 	uint32_t target = fatfs_getOperationalParameter(OP_PARAMETER_CAM_AE_TARGET);
 	if ((target == 0) || (target > 250)) {

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/ae.h
@@ -44,4 +44,11 @@ void ae_notifySensorInit(void);
  */
 bool ae_process(uint32_t yAddr, uint16_t w, uint16_t h);
 
+/**
+ * As ae_process(), but with the bright-quartile luma already measured by the
+ * caller (used by the high-resolution capture, which measures the raw Bayer
+ * green channel instead of a demosaiced Y plane).
+ */
+bool ae_process_measured(uint32_t p75Raw);
+
 #endif /* AE_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/cis_sensor/cis_imx708/cisdp_sensor.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/cis_sensor/cis_imx708/cisdp_sensor.c
@@ -100,12 +100,43 @@ static HX_CIS_SensorSetting_t  IMX708_mirror_setting[] = {
 		{HX_CIS_I2C_Action_W, 0x0101, (CIS_MIRROR_SETTING&0xFF)},
 };
 
+// High-resolution RAW capture override (see hires.c): when nonzero, the
+// datapath is configured as INP centre-crop -> RAW -> WDMA2 at this address
+// instead of the integrated HW5x5+JPEG flow.
+#define HIRES_RAW_WIDTH		1280
+#define HIRES_RAW_HEIGHT	960
+static uint32_t g_hires_raw_addr = 0;
+
+void cisdp_set_hires_raw(uint32_t rawAddr)
+{
+	g_hires_raw_addr = rawAddr;
+}
+
+uint8_t cisdp_get_demos_pattern(void)
+{
+	// Order matches demosaic_pattern_t (demosaic.h). DP_HW5X5_DEMOS_PATTERN
+	// expands to an enum constant, so this folds at compile time.
+	switch (DP_HW5X5_DEMOS_PATTERN) {
+	case DEMOS_PATTENMODE_RGGB: return 0;
+	case DEMOS_PATTENMODE_GRBG: return 1;
+	case DEMOS_PATTENMODE_GBRG: return 2;
+	default:                    return 3;	// BGGR
+	}
+}
+
 static void cisdp_wdma_addr_init(APP_DP_INP_SUBSAMPLE_E subs)
 {
-    sensordplib_set_xDMA_baseaddrbyapp(g_wdma1_baseaddr, g_wdma2_baseaddr, g_wdma3_baseaddr);
+	if (g_hires_raw_addr != 0) {
+		// WDMA2 carries the RAW Bayer frame for the CPU pipeline
+		sensordplib_set_xDMA_baseaddrbyapp(g_wdma1_baseaddr, g_hires_raw_addr, g_wdma3_baseaddr);
+	}
+	else {
+		sensordplib_set_xDMA_baseaddrbyapp(g_wdma1_baseaddr, g_wdma2_baseaddr, g_wdma3_baseaddr);
+	}
     sensordplib_set_jpegfilesize_addrbyapp(g_jpegautofill_addr);
 
-	xprintf("WD1[%x], WD2_J[%x], WD3_RAW[%x], JPAuto[%x]\n",g_wdma1_baseaddr, g_wdma2_baseaddr,
+	xprintf("WD1[%x], WD2_J[%x], WD3_RAW[%x], JPAuto[%x]\n",g_wdma1_baseaddr,
+			(g_hires_raw_addr != 0) ? g_hires_raw_addr : g_wdma2_baseaddr,
 			g_wdma3_baseaddr, g_jpegautofill_addr);
 }
 
@@ -483,21 +514,33 @@ int cisdp_dp_init(bool inp_init, SENSORDPLIB_PATH_E dp_type, sensordplib_CBEvent
 	set_mipi_csirx_enable();
 
     INP_CROP_T crop;
-    crop.start_x = DP_INP_CROP_START_X;
-    crop.start_y = DP_INP_CROP_START_Y;
+    if (g_hires_raw_addr != 0) {
+    	// High-resolution RAW capture (hires.c): centre-crop the sensor's
+    	// 2304x1296 stream to 1280x960 in the INP block. The RAW Bayer frame
+    	// goes to WDMA2 at the address hires.c registered (the CPU demosaics
+    	// and JPEG-encodes it in strips - the HW5x5/JPEG blocks are bypassed).
+    	crop.start_x = (SENCTRL_SENSOR_WIDTH - HIRES_RAW_WIDTH) / 2;		// 512
+    	crop.start_y = (SENCTRL_SENSOR_HEIGHT - HIRES_RAW_HEIGHT) / 2;		// 168
+    	crop.last_x = crop.start_x + HIRES_RAW_WIDTH - 1;
+    	crop.last_y = crop.start_y + HIRES_RAW_HEIGHT - 1;
+    }
+    else {
+    	crop.start_x = DP_INP_CROP_START_X;
+    	crop.start_y = DP_INP_CROP_START_Y;
 
-    if(DP_INP_CROP_WIDTH >= 1) {
-    	crop.last_x = DP_INP_CROP_START_X + DP_INP_CROP_WIDTH - 1;
-}
-    else {
-    	crop.last_x = 0;
-	}
-    if(DP_INP_CROP_HEIGHT >= 1) {
-    	crop.last_y = DP_INP_CROP_START_Y + DP_INP_CROP_HEIGHT - 1;
-	}
-    else {
-    	crop.last_y = 0;
- 	}
+    	if(DP_INP_CROP_WIDTH >= 1) {
+    		crop.last_x = DP_INP_CROP_START_X + DP_INP_CROP_WIDTH - 1;
+    	}
+    	else {
+    		crop.last_x = 0;
+    	}
+    	if(DP_INP_CROP_HEIGHT >= 1) {
+    		crop.last_y = DP_INP_CROP_START_Y + DP_INP_CROP_HEIGHT - 1;
+    	}
+    	else {
+    		crop.last_y = 0;
+    	}
+    }
 
     sensordplib_set_sensorctrl_inp_wi_crop(SENCTRL_SENSOR_TYPE, SENCTRL_STREAM_TYPE, SENCTRL_SENSOR_WIDTH, SENCTRL_SENSOR_HEIGHT, DP_INP_SUBSAMPLE, crop);
 
@@ -507,8 +550,14 @@ int cisdp_dp_init(bool inp_init, SENSORDPLIB_PATH_E dp_type, sensordplib_CBEvent
 	switch (dp_type)
 	{
 	case SENSORDPLIB_PATH_INP_WDMA2:
-	    sensordplib_set_raw_wdma2(DP_INP_OUT_WIDTH, DP_INP_OUT_HEIGHT,
-	    		NULL);
+		if (g_hires_raw_addr != 0) {
+			sensordplib_set_raw_wdma2(HIRES_RAW_WIDTH, HIRES_RAW_HEIGHT,
+					NULL);
+		}
+		else {
+			sensordplib_set_raw_wdma2(DP_INP_OUT_WIDTH, DP_INP_OUT_HEIGHT,
+					NULL);
+		}
 	    break;
 	case SENSORDPLIB_PATH_INP_HW2x2_CDM:
 	    sensordplib_set_HW2x2_CDM(hw2x2_cfg, cdm_cfg,

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/cis_sensor/cis_imx708/cisdp_sensor.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/cis_sensor/cis_imx708/cisdp_sensor.h
@@ -50,6 +50,17 @@ uint32_t app_get_raw_width();
 uint32_t app_get_raw_height();
 uint32_t app_get_raw_channels();
 
+/*
+ * High-resolution RAW capture support (hires.c). Register a nonzero raw
+ * buffer address BEFORE cisdp_dp_init() to switch the datapath to
+ * INP centre-crop (1280x960) -> RAW Bayer -> WDMA2 at that address,
+ * bypassing HW5x5/JPEG. Register 0 to restore the normal VGA flow.
+ */
+void cisdp_set_hires_raw(uint32_t rawAddr);
+
+/* CFA phase of the demosaic, as a demosaic_pattern_t value (demosaic.h) */
+uint8_t cisdp_get_demos_pattern(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/demosaic.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/demosaic.c
@@ -1,0 +1,175 @@
+/*
+ * demosaic.c
+ *
+ * CPU bilinear Bayer demosaic + fused colour pipeline. See demosaic.h.
+ *
+ * Bilinear rules per site:
+ *   at a red/blue site:   the other diagonal colour = avg of 4 diagonals,
+ *                         green = avg of 4 edge neighbours
+ *   at a green site:      red/blue = avg of the 2 horizontal or 2 vertical
+ *                         neighbours (which is which depends on the row)
+ * Edges clamp. Quality is adequate for a wildlife trail-cam JPEG; the
+ * sharper malvar kernel can be swapped in later without API changes.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "img_correct.h"	// img_correct_transform_rgb()
+#include "demosaic.h"
+
+// Colour of the CFA site at (x, y) for a pattern: 0=R 1=G 2=B
+static inline int site_colour(demosaic_pattern_t p, uint32_t x, uint32_t y) {
+	static const uint8_t site[4][4] = {
+		// (even,even) (odd,even) (even,odd) (odd,odd)
+		{ 0, 1, 1, 2 },		// RGGB
+		{ 1, 0, 2, 1 },		// GRBG
+		{ 1, 2, 0, 1 },		// GBRG
+		{ 2, 1, 1, 0 },		// BGGR
+	};
+	return site[p][((y & 1u) << 1) | (x & 1u)];
+}
+
+static inline uint32_t clamp_u(int32_t v, int32_t lo, int32_t hi) {
+	if (v < lo) return (uint32_t)lo;
+	if (v > hi) return (uint32_t)hi;
+	return (uint32_t)v;
+}
+
+// Fetch with edge clamp
+static inline int32_t px(const uint8_t *b, uint32_t w, uint32_t h,
+						 int32_t x, int32_t y) {
+	uint32_t cx = clamp_u(x, 0, (int32_t)w - 1);
+	uint32_t cy = clamp_u(y, 0, (int32_t)h - 1);
+	return (int32_t)b[cy * w + cx];
+}
+
+/**
+ * Reconstruct R,G,B at (x,y) by bilinear interpolation.
+ */
+static void demosaic_px(const uint8_t *b, uint32_t w, uint32_t h,
+						demosaic_pattern_t p, int32_t x, int32_t y,
+						int32_t *R, int32_t *G, int32_t *B) {
+	int c = site_colour(p, (uint32_t)x, (uint32_t)y);
+	int32_t self = px(b, w, h, x, y);
+
+	int32_t edges = (px(b, w, h, x - 1, y) + px(b, w, h, x + 1, y)
+			+ px(b, w, h, x, y - 1) + px(b, w, h, x, y + 1) + 2) >> 2;
+	int32_t diags = (px(b, w, h, x - 1, y - 1) + px(b, w, h, x + 1, y - 1)
+			+ px(b, w, h, x - 1, y + 1) + px(b, w, h, x + 1, y + 1) + 2) >> 2;
+	int32_t horiz = (px(b, w, h, x - 1, y) + px(b, w, h, x + 1, y) + 1) >> 1;
+	int32_t vert  = (px(b, w, h, x, y - 1) + px(b, w, h, x, y + 1) + 1) >> 1;
+
+	if (c == 0) {						// red site
+		*R = self;
+		*G = edges;
+		*B = diags;
+	}
+	else if (c == 2) {					// blue site
+		*B = self;
+		*G = edges;
+		*R = diags;
+	}
+	else {								// green site
+		*G = self;
+		// which colour lies horizontally beside this green depends on the row:
+		// the row containing red sites has R horizontal, B vertical (and vice
+		// versa). Row contains red iff site_colour at (x^1, y) == 0.
+		if (site_colour(p, (uint32_t)(x ^ 1), (uint32_t)y) == 0) {
+			*R = horiz;
+			*B = vert;
+		}
+		else {
+			*R = vert;
+			*B = horiz;
+		}
+	}
+}
+
+void demosaic_measure(const uint8_t *bayer, uint32_t w, uint32_t h,
+					  demosaic_pattern_t pattern,
+					  uint32_t *rMean, uint32_t *gMean, uint32_t *bMean,
+					  uint32_t *gP75) {
+	uint32_t sum[3] = {0, 0, 0};
+	uint32_t cnt[3] = {0, 0, 0};
+	uint32_t hist[32] = {0};
+	uint32_t nG = 0;
+
+	// Sample every 8th row/column pair (keeps all four CFA phases sampled)
+	for (uint32_t y = 0; y + 1 < h; y += 8) {
+		for (uint32_t x = 0; x + 1 < w; x += 8) {
+			// the 2x2 cell at (x,y) contains each colour at least once
+			for (uint32_t dy = 0; dy < 2; dy++) {
+				for (uint32_t dx = 0; dx < 2; dx++) {
+					uint8_t v = bayer[(y + dy) * w + (x + dx)];
+					int c = site_colour(pattern, x + dx, y + dy);
+					sum[c] += v;
+					cnt[c]++;
+					if (c == 1) {
+						hist[v >> 3]++;
+						nG++;
+					}
+				}
+			}
+		}
+	}
+
+	*rMean = cnt[0] ? (sum[0] / cnt[0]) : 0;
+	*gMean = cnt[1] ? (sum[1] / cnt[1]) : 0;
+	*bMean = cnt[2] ? (sum[2] / cnt[2]) : 0;
+
+	uint32_t threshold = (nG * 3u) / 4u;
+	uint32_t cum = 0;
+	*gP75 = 255;
+	for (int bin = 0; bin < 32; bin++) {
+		cum += hist[bin];
+		if (cum >= threshold) {
+			*gP75 = ((uint32_t)bin << 3) + 4;
+			break;
+		}
+	}
+}
+
+void demosaic_strip_yuv420(const uint8_t *bayer, uint32_t w, uint32_t h,
+						   uint32_t rowStart, demosaic_pattern_t pattern,
+						   uint16_t rGainQ8, uint16_t bGainQ8,
+						   uint8_t *stripYuv) {
+	uint8_t *yPlane = stripYuv;
+	uint8_t *uPlane = stripYuv + (w * 16u);
+	uint8_t *vPlane = uPlane + ((w / 2u) * 8u);
+	uint32_t cw = w / 2u;
+
+	// Process in 2x2 blocks (YUV420: 4 Y share one Cb,Cr)
+	for (uint32_t by = 0; by < 16; by += 2) {
+		uint32_t srcY = rowStart + by;
+		for (uint32_t bx = 0; bx < w; bx += 2) {
+			int32_t sumCb = 0, sumCr = 0;
+
+			for (uint32_t dy = 0; dy < 2; dy++) {
+				for (uint32_t dx = 0; dx < 2; dx++) {
+					int32_t R, G, B;
+					demosaic_px(bayer, w, h, pattern,
+								(int32_t)(bx + dx), (int32_t)(srcY + dy), &R, &G, &B);
+
+					// black level -> WB -> CCM -> gamma (shared pipeline)
+					img_correct_transform_rgb(&R, &G, &B, rGainQ8, bGainQ8);
+
+					// RGB -> YCbCr (JPEG full range, x256 coefficients)
+					int32_t Y = (77 * R + 150 * G + 29 * B) >> 8;
+					if (Y > 255) Y = 255;
+					yPlane[(by + dy) * w + (bx + dx)] = (uint8_t)Y;
+
+					sumCb += ((-43 * R - 85 * G + 128 * B) >> 8);
+					sumCr += ((128 * R - 107 * G - 21 * B) >> 8);
+				}
+			}
+
+			int32_t cb = 128 + (sumCb >> 2);
+			int32_t cr = 128 + (sumCr >> 2);
+			if (cb < 0) cb = 0; else if (cb > 255) cb = 255;
+			if (cr < 0) cr = 0; else if (cr > 255) cr = 255;
+			uPlane[(by >> 1) * cw + (bx >> 1)] = (uint8_t)cb;
+			vPlane[(by >> 1) * cw + (bx >> 1)] = (uint8_t)cr;
+		}
+	}
+}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/demosaic.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/demosaic.h
@@ -1,0 +1,58 @@
+/*
+ * demosaic.h
+ *
+ * CPU Bayer demosaic for the high-resolution capture path (hires.c).
+ *
+ * The WE2's HW5x5 demosaic block tops out at 640x480, so frames captured
+ * RAW at 1280x960 are demosaiced on the CM55M instead - one 16-row strip
+ * at a time, feeding the streaming software JPEG encoder (sw_jpeg.h), so
+ * no full-frame YUV buffer is ever needed. The colour pipeline (black
+ * level -> WB -> CCM -> gamma, img_correct_transform_rgb()) is fused into
+ * the same pass.
+ *
+ * Also provides raw-domain scene measurement (channel means for the auto
+ * white balance, green-channel bright-quartile for the auto exposure), so
+ * gains are computed once per frame - uniform across the image.
+ */
+
+#ifndef DEMOSAIC_H_
+#define DEMOSAIC_H_
+
+#include <stdint.h>
+
+// CFA phase: colour of the (even col, even row) / (odd,even) / (even,odd) /
+// (odd,odd) sites. Values match the order of DEMOS_PATTENMODE_* usage in
+// cisdp_cfg.h via cisdp_get_demos_pattern().
+typedef enum {
+	DEMOSAIC_PATTERN_RGGB = 0,
+	DEMOSAIC_PATTERN_GRBG = 1,
+	DEMOSAIC_PATTERN_GBRG = 2,
+	DEMOSAIC_PATTERN_BGGR = 3,
+} demosaic_pattern_t;
+
+/**
+ * Subsampled raw-domain scene measurement.
+ * Means are per-channel (R/G/B taken only from their own CFA sites);
+ * gP75 is the green-channel bright-quartile (32-bin histogram midpoint),
+ * the input for ae_process_measured().
+ */
+void demosaic_measure(const uint8_t *bayer, uint32_t w, uint32_t h,
+					  demosaic_pattern_t pattern,
+					  uint32_t *rMean, uint32_t *gMean, uint32_t *bMean,
+					  uint32_t *gP75);
+
+/**
+ * Demosaic one strip of 16 rows (rows rowStart .. rowStart+15) to planar
+ * YUV420 with the colour pipeline applied, laid out for
+ * sw_jpeg_stream_strip(): Y (w*16), Cb (w/2 * 8), Cr (w/2 * 8).
+ *
+ * The full Bayer frame must be resident (neighbour rows are read across
+ * strip boundaries; edges clamp). w and rowStart must be even; the strip
+ * must lie fully inside the image.
+ */
+void demosaic_strip_yuv420(const uint8_t *bayer, uint32_t w, uint32_t h,
+						   uint32_t rowStart, demosaic_pattern_t pattern,
+						   uint16_t rGainQ8, uint16_t bGainQ8,
+						   uint8_t *stripYuv);
+
+#endif /* DEMOSAIC_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
@@ -1,0 +1,146 @@
+# Motion-Detection Presets — HM0360 parameter blueprint
+
+**Status:** design + roadmap (2026-07). **Goal:** replace the current 3-knob
+`MD_SENSITIVITY` with four project-level, user-facing presets that map real
+deployment profiles (noise rejection, slow invertebrates, fast predators, small
+lizards) onto the HM0360's motion-detection registers.
+
+> **The current values are unvalidated.** The MD registers today hold Himax's
+> generic reference init (from `github.com/stevehuang82/for_wildlife_ai`), never
+> characterised against skinks, stoats, or waving grass. Section 5 is the plan to
+> fix that; the numbers in Section 3 are **starting hypotheses**, not final values.
+
+---
+
+## 1. Architecture reality (read this first)
+
+Two facts reshape any "motion tuning" work on the WW500:
+
+1. **Motion detection is the HM0360 sensor's job, not the HX6538's.** The HX6538
+   (WiseEye WE2: Cortex-M55 + Ethos-U55 microNPU) is in **deep power-down** while
+   watching for motion; the HM0360 runs its onboard MD engine at ~270 µA and wakes
+   the SoC by interrupt. Even on the RP-camera (IMX708) build, an HM0360 is fitted
+   purely as the MD sensor (see [`hm0360_md.c`](../hm0360_md.c)). The HX6538
+   datasheets describe the **AI SoC** — they contain no MD/optical-flow block.
+
+2. **There is no optical flow, no velocity vector, no block motion-estimation.**
+   The HM0360 does **frame differencing → a 16×16 macroblock "changed?" bitmap
+   (`MD_ROI_OUT`, 32 registers `0x20A1–0x20C0`) → block-count + persistence + IIR**.
+   "Velocity" can only be *approximated* by the sample interval (Δt) and the
+   latency/persistence frames. Any spec that assumes directional motion vectors is
+   assuming hardware this camera does not have.
+
+## 2. What's tunable today vs. what's fixed
+
+`cisdp_sensor_set_md_sensitivity()` ([`cisdp_sensor.c`](../cis_sensor/cis_hm0360/cisdp_sensor.c))
+selects one of `OFF/LOW/MEDIUM/HIGH` (OP 17), and each table bends **only three
+knobs**: `MD_TH_STR`, `MD_LIGHT_COEF`, `MD_IIR_PARAM`. The powerful knobs sit at the
+one-time init defaults — and the author already **scaffolded `MD_BLOCK_NUM_TH` + ROI
+as commented-out lines** in those same tables:
+
+| Register | Addr (ctx-B) | Current | Varied by preset today? | Controls |
+|---|---|---|---|---|
+| `MD_TH_STR_L/H` | `0x35AA/0x35A9` | 0x10–0x30 | ✅ (sensitivity) | per-block change magnitude (↓ = more sensitive) |
+| `MD_LIGHT_COEF` | `0x35A5` | 0x21–0x41 | ✅ | illumination compensation |
+| `MD_IIR_PARAM` | `0x209A` | 0x00/0x80/0xF0 | ✅ | background-model IIR *(transfer fn undocumented)* |
+| `MD_BLOCK_NUM_TH` | `0x35A6` / `0x209B` | **0x04** | ❌ fixed (scaffolded) | **# blocks that must change to fire → target/cluster size** |
+| `MD_LATENCY_TH` | `0x209D` | **0x33** | ❌ fixed | **frame persistence `[7:4]=set,[3:0]=clear`** |
+| `MD_LATENCY` / `MD_CTRL[5:4]` | `0x209C` / `0x2080=0x31` | **0x01 / lat-sel** | ❌ fixed | latency depth / select |
+| `MD_TH_MIN` | `0x2083` | **0x01** | ❌ fixed | threshold floor |
+| `ROI_V / ROI_H` | `0x35A7/0x35A8` | **0xE0/0xF0 = full frame** | ❌ fixed | **watch-window (4-bit start/end on the 16-grid)** |
+| Δt (`PMU_CFG_8/9`) | `0x3029/0x302A` | 0x1560 | via **OP 11 `MD_INTERVAL`** at runtime | **inter-sample interval** |
+
+Confidence note: `MD_TH_STR`, `MD_BLOCK_NUM_TH`, ROI and Δt have clear, monotonic
+meaning. `MD_IIR_PARAM` and the `MD_LATENCY_TH` nibble semantics are **inferred from
+the reference init comments** (no HM0360 datasheet exists) and must be characterised
+before being trusted (Section 5, Phase 1).
+
+## 3. The four presets
+
+Starting hypotheses — the backbone knobs are directionally sound; IIR/latency are to
+be pinned by the bench sweep.
+
+| Lever | P1 High-Noise / Medium | P2 Macro / Ultra-slow | P3 High-Velocity | P4 Micro / Small |
+|---|---|---|---|---|
+| `MD_TH_STR` | high **0x28** | low-med **0x18** | med **0x20** | **low 0x10** |
+| `MD_BLOCK_NUM_TH` | **high 0x0A–0x10** | **low 0x01–0x02** | low-med **0x03** | **lowest 0x01** |
+| `MD_LATENCY_TH` | **high (persist)** | low | **≈0 (fire on 1st frame)** | med |
+| `MD_IIR_PARAM` † | strong bg-absorb | **off (0x00)** | low | med |
+| ROI | **exclude top ⅓** | full / macro-centre | full | **ground band** |
+| Δt (OP 11) | ~1 s | **multi-second** | **short / fast** | medium |
+| `MD_LIGHT_COEF` | high 0x41 | low 0x21 | 0x31 | 0x31 |
+
+† IIR direction pending Phase-1 characterisation.
+
+**Rationale.** **P1** rejects noise on multiple axes at once (bigger change, bigger
+cluster, longer persistence) and drops the moving canopy via ROI. **P2**'s core trick
+is a **wide Δt with the background model not absorbing the subject** — a slug displaces
+enough between far-apart samples to differ. **P3** trades power for a fast sample rate +
+near-zero persistence so an agile predator is caught before it exits. **P4** minimises
+both the per-block threshold and the block-count so a 1–2-block skink registers.
+
+**Honest limits.** P3 "velocity" is emulated by rate+latency, *not measured*. And
+**camera-swing** (in P1's environment) produces whole-frame motion that MD cannot cleanly
+separate from a real subject — that is a **mounting/mechanical** fix first, not a register
+fix (see [`WW500_camera_operation.md`](./WW500_camera_operation.md) for mounting notes).
+
+## 4. Firmware & app integration
+
+- **Model.** A preset is a *bundle* (register table + Δt + ROI), so don't overload the
+  3-knob `MD_SENSITIVITY`. Add **`OP_PARAMETER_MD_PRESET`** (next free index, OP 29 — see
+  [`MANIFEST/config_file.md`](../MANIFEST/config_file.md)) selecting one of four
+  `HX_CIS_SensorSetting_t` preset tables that extend the existing `HM0360_md_sensitivity_*`
+  pattern (un-comment + populate the `MD_BLOCK_NUM_TH`/ROI lines, add `MD_LATENCY_TH`). The
+  preset also sets `OP 11 MD_INTERVAL` (Δt).
+- **Backend / project scope.** Projects already carry `activity_detection_sensitivity_id`
+  (ww-backend seed) — extend that to the 4 presets; it reaches the device via CONFIG.TXT /
+  the manifest like other OPs.
+- **BLE.** The app already writes OPs over BLE (`setop`, persisted immediately to
+  CONFIG.TXT). One value travels: `MD_PRESET = 1..4`.
+- **Crash-safe apply (critical).** Never rewrite MD registers mid-stream. Apply on
+  *change* only, at DPD-entry (`hm0360_md_prepare()`), in this order:
+  **`MODE_SLEEP` → write preset table (both contexts) → set Δt (`PMU_CFG_8/9`) →
+  enable MD interrupt → DPD.** The HM0360 retains its registers across the SoC's DPD, so
+  no per-wake reprogramming is needed. `hm0360_md_setMode()` already routes through
+  `MODE_SLEEP` before writes — reuse it.
+
+## 5. Roadmap
+
+- **Phase 0 — Instrumentation (prereq).** CLI to read/write every MD register and dump the
+  live 256-block grid (`hm0360_md_printGrid()` already renders it) + log `motionCount` per
+  trigger; a register-sweep harness. *Everything downstream depends on this.*
+- **Phase 1 — Bench characterisation.** Run §6's rigs and **measure** detection vs each
+  register; replace §3's placeholders with data (detection-rate vs false-trigger-rate per
+  preset). This is the "fit for purpose" work that has never been done.
+- **Phase 2 — Firmware presets.** Encode the 4 validated tables + `OP_PARAMETER_MD_PRESET`;
+  wire block-num / ROI / latency / Δt into the bundle.
+- **Phase 3 — Config + BLE plumbing.** OP over BLE → CONFIG.TXT → manifest; backend
+  `activity_detection_sensitivity_id` → preset; app UI stub.
+- **Phase 4 — Field validation (free ground truth).** Deploy each preset and score MD
+  against the SD-card upload via the website's Cloud AI: **"MD woke but Cloud AI says
+  *blank*" = false trigger; "animal in frame, no wake" = miss.** The dual-AI pipeline is the
+  MD validation oracle — no manual labelling.
+- **Phase 5 — App UX.** Ship the four named presets.
+
+## 6. QA & physical-testing matrix
+
+| Axis | Method | Validates | Presets |
+|---|---|---|---|
+| Speed | servo/stepper rail or pendulum carrying a cut-out at calibrated mm/s; metronome for cadence | latency + Δt (catch-before-exit) | P3, P2 |
+| Ultra-slow | linear actuator at mm/**min** (snail rig) | wide-Δt detection, IIR-off | P2 |
+| Size | graded cut-outs (3 cm skink → 30 cm possum) + laser dot at fixed distance → known block footprint | `MD_BLOCK_NUM_TH`, `MD_TH_STR` | P4, P1 |
+| Env. noise | fan + artificial foliage; projected moving shadow; strobe for shifting light | false-trigger rate, IIR, `LIGHT_COEF` | P1 |
+| Camera-swing | pendulum/spring camera mount | whole-frame-motion rejection (expose the limit) | P1 |
+| Combos | full `{size × speed × noise}` grid per preset | preset separation | all |
+
+**Metrics per preset:** detection rate, false triggers/hour, entry→trigger latency (ms),
+average current (µA), miss rate — each logged with the 256-block grid so failures are
+diagnosable, cross-checked against Cloud AI verdicts in the field.
+
+## References
+
+- [`hm0360_regs.h`](../hm0360_regs.h) — register addresses.
+- [`cisdp_sensor.c`](../cis_sensor/cis_hm0360/cisdp_sensor.c) — current `MD_SENSITIVITY` tables.
+- [`hm0360_md.c`](../hm0360_md.c) — MD mode/interrupt/ROI-readout + Δt (`calculateSleepTime`).
+- `cis_hm0360/HM0360_OSC_Bayer_640x480_setA_VGA_setB_QVGA_md_8b_ParallelOutput_R2.i` — init defaults.
+- [`MANIFEST/config_file.md`](../MANIFEST/config_file.md) — Operational Parameters (OP 11, 17).

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
@@ -106,12 +106,21 @@ fix (see [`WW500_camera_operation.md`](./WW500_camera_operation.md) for mounting
 
 ## 5. Roadmap
 
-- **Phase 0 — Instrumentation (prereq).** CLI to read/write every MD register and dump the
-  live 256-block grid (`hm0360_md_printGrid()` already renders it) + log `motionCount` per
-  trigger; a register-sweep harness. *Everything downstream depends on this.*
-- **Phase 1 — Bench characterisation.** Run §6's rigs and **measure** detection vs each
-  register; replace §3's placeholders with data (detection-rate vs false-trigger-rate per
-  preset). This is the "fit for purpose" work that has never been done.
+- **Phase 0 — Instrumentation (prereq). _Done (2026-07-11)._** Read/write every MD register
+  on real hardware over the **stock `camreg`** command (no reflash needed) — the headless
+  sweep harness is `_Tools/md_sweep.py` (reconnect-pin, per-step re-pin, `MD_ROI_OUT`
+  popcount / `INT_INDIC` fired bit). The `md read/write/grid/dump` CLI + `hm0360_md_printGrid`
+  are the flashed-firmware equivalent. **Serial map:** Himax MD console = **COM13 @ 921600**
+  (COM14 = nRF). **Key finding:** the HM0360 MD engine only runs on the **sleep path** — a
+  register poll while the SoC is pinned awake reads 0 at every threshold.
+- **Phase 1 — Bench characterisation.** Two rigs now exist: (a) `md_sweep.py` for headless
+  register sweeps, and (b) the **live MD overlay in `live_view.py`** — preview arms MD
+  concurrently (`hm0360_md_prepare(true,…)` in `preview.c`) and streams the 16×16 grid, so
+  you watch which blocks light up over the live image while editing `camreg`/`setop`. Run
+  §6's rigs and **measure** detection vs each register; replace §3's placeholders with data
+  (detection-rate vs false-trigger-rate per preset). This is the "fit for purpose" work that
+  has never been done. (Note: the true field trigger is a sleep→motion→**wake**, so also
+  score via the sleep-wake path — watch the nRF's `AI processor sends stats` on COM14.)
 - **Phase 2 — Firmware presets.** Encode the 4 validated tables + `OP_PARAMETER_MD_PRESET`;
   wire block-num / ROI / latency / Δt into the bundle.
 - **Phase 3 — Config + BLE plumbing.** OP over BLE → CONFIG.TXT → manifest; backend

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/Motion_detection_presets.md
@@ -55,6 +55,18 @@ meaning. `MD_IIR_PARAM` and the `MD_LATENCY_TH` nibble semantics are **inferred 
 the reference init comments** (no HM0360 datasheet exists) and must be characterised
 before being trusted (Section 5, Phase 1).
 
+**Software companion knob — global-motion rejection (`OP_PARAMETER_MD_BLOCK_NUM_MAX`,
+op 33, added 2026-07-13).** The sensor only has a *minimum* trigger (`MD_BLOCK_NUM_TH`:
+"at least N blocks moved"); there is no hardware *maximum*, so a whole-scene shift
+(camera knock/pan, cloud/lighting flip) fires like any animal — but lights **most of
+the 256 blocks** instead of a small cluster. The firmware now reads the triggering
+bitmap at MD wake (before the interrupt clear / capture start, `image_task.c`) and
+**skips the capture when the count exceeds op 33** (0 = disabled; try 100–180). The
+wake itself cannot be prevented — this saves the false capture/save/upload, not the
+wake power. Rejections are reported to the BLE master ("MD wake rejected: motion in
+N blocks > max M"). A future refinement is a *spread/cluster* check on the same
+bitmap (animal = compact cluster; global motion = edge-to-edge smear).
+
 ## 3. The four presets
 
 Starting hypotheses — the backbone knobs are directionally sound; IIR/latency are to

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -99,7 +99,7 @@
 // Length of lines in configuration.txt
 #define MAXCOMMENTLENGTH 80
 // Max number of comment lines in configuration.txt
-#define MAXNUMCOMMENTS OP_PARAMETER_NUM_ENTRIES + 5
+#define MAXNUMCOMMENTS (OP_PARAMETER_NUM_ENTRIES + 5)
 
 /*************************************** Local Function Declarations *****************************/
 
@@ -1151,7 +1151,13 @@ FRESULT save_configuration(const char *filename, directoryManager_t *dirManager)
 	FRESULT res;
 	UINT bytesWritten;
 	char line[MAXCOMMENTLENGTH];
-	char comment_lines[MAXNUMCOMMENTS][MAXCOMMENTLENGTH];
+	// Static, NOT a stack local: this array is MAXNUMCOMMENTS * 80 bytes
+	// (over 3 KB and growing with every op parameter added), which
+	// overflowed the FatFS task stack and corrupted a return address the
+	// moment op_parameter[] reached 33 entries (UsageFault on every boot's
+	// first config save). Only the FatFS task calls this, so a single
+	// static buffer is safe.
+	static char comment_lines[MAXNUMCOMMENTS][MAXCOMMENTLENGTH];
 	uint16_t comment_count = 0;
 
     if (!fatfs_mounted()) {

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -250,6 +250,7 @@ uint16_t op_parameter[OP_PARAMETER_NUM_ENTRIES] = {
 	110,	   			// 30 OP_PARAMETER_CAM_AE_TARGET (target mean luma; 0 = built-in default)
 	1,	    	   		// 31 OP_PARAMETER_CAM_WB_MODE (1 = auto grey-world; 2 = manual op27/28; 0 = off)
 	0,	    	   		// 32 OP_PARAMETER_CAM_RESOLUTION (0 = 640x480; 1 = 1280x960, needs op14 = 0)
+	0,	    	   		// 33 OP_PARAMETER_MD_BLOCK_NUM_MAX (global-motion rejection; 0 = disabled)
 };
 
 // Deployment ID UUID string — loaded from 'I ' line in CONFIG.TXT or set via setdid CLI command

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.c
@@ -249,6 +249,7 @@ uint16_t op_parameter[OP_PARAMETER_NUM_ENTRIES] = {
 	1,	    	   		// 29 OP_PARAMETER_CAM_AE_ENABLE (RP camera auto-exposure on/off - see ae.c)
 	110,	   			// 30 OP_PARAMETER_CAM_AE_TARGET (target mean luma; 0 = built-in default)
 	1,	    	   		// 31 OP_PARAMETER_CAM_WB_MODE (1 = auto grey-world; 2 = manual op27/28; 0 = off)
+	0,	    	   		// 32 OP_PARAMETER_CAM_RESOLUTION (0 = 640x480; 1 = 1280x960, needs op14 = 0)
 };
 
 // Deployment ID UUID string — loaded from 'I ' line in CONFIG.TXT or set via setdid CLI command

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
@@ -92,6 +92,7 @@ typedef enum {
 	OP_PARAMETER_CAM_AE_ENABLE,		// 29 RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. See ae.c
 	OP_PARAMETER_CAM_AE_TARGET,		// 30 RP camera auto-exposure target mean luma (0-250; 0 = built-in default 110). See ae.c
 	OP_PARAMETER_CAM_WB_MODE,		// 31 RP camera white balance: 0 = off, 1 = auto (grey-world per frame), 2 = manual op27/op28. See img_correct.c
+	OP_PARAMETER_CAM_RESOLUTION,	// 32 RP camera capture resolution: 0 = 640x480, 1 = 1280x960 single JPEG (requires NN off, op14 = 0). See hires.c
 
 	OP_PARAMETER_NUM_ENTRIES		// Not an Operational Parameters - serves to define the size of the op_parameter[] array
 } OP_PARAMETERS_E;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/fatfs_task.h
@@ -93,6 +93,7 @@ typedef enum {
 	OP_PARAMETER_CAM_AE_TARGET,		// 30 RP camera auto-exposure target mean luma (0-250; 0 = built-in default 110). See ae.c
 	OP_PARAMETER_CAM_WB_MODE,		// 31 RP camera white balance: 0 = off, 1 = auto (grey-world per frame), 2 = manual op27/op28. See img_correct.c
 	OP_PARAMETER_CAM_RESOLUTION,	// 32 RP camera capture resolution: 0 = 640x480, 1 = 1280x960 single JPEG (requires NN off, op14 = 0). See hires.c
+	OP_PARAMETER_MD_BLOCK_NUM_MAX,	// 33 Global-motion rejection: skip the capture when an MD wake shows motion in MORE than this many of the 256 grid blocks (whole-scene shift = camera knock/pan/lighting, not an animal). 0 disables. See image_task.c
 
 	OP_PARAMETER_NUM_ENTRIES		// Not an Operational Parameters - serves to define the size of the op_parameter[] array
 } OP_PARAMETERS_E;

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hardfault_handler.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hardfault_handler.c
@@ -123,7 +123,11 @@ void BusFault_Handler(void) {
 	}
 }
 void UsageFault_Handler(void) {
+	// CFSR's UsageFault byte says WHY (bit16 UNDEFINSTR, 17 INVSTATE,
+	// 18 INVPC, 19 NOCP, 24 UNALIGNED, 25 DIVBYZERO)
 	xprintf("\r\nEntering UsageFault_Handler interrupt!\r\n");
+	xprintf("SCB->CFSR:0x%08x\n", (int) SCB->CFSR);
+	xprintf("SCB->HFSR:0x%08x\n", (int) SCB->HFSR);
 	for (;;) {
 	}
 }

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hires.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hires.c
@@ -1,0 +1,172 @@
+/*
+ * hires.c
+ *
+ * Single-file 1280x960 capture. See hires.h for the architecture and
+ * _Documentation/hires-capture.md for the design rationale and bench data.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "WE2_core.h"		// SCB_InvalidateDCache_by_Addr
+#include "xprintf.h"
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#include "fatfs_task.h"
+#include "cisdp_sensor.h"
+#include "img_correct.h"
+#include "demosaic.h"
+#include "sw_jpeg.h"
+#include "ae.h"
+#include "cvapp.h"			// cv_modelLoaded()
+#include "hires.h"
+
+#define HIRES_JPEG_QUALITY	85
+
+// Raw Bayer frame: 1280*960 = 1,228,800 B. Overlays the tensor arena
+// (512 KB, idle when no NN model is loaded) and runs into the free SRAM
+// tail after it (nothing else is linked beyond the arena - see the .map).
+extern uint8_t __tensor_arena_start__;
+#define SRAM_REGION_END		0x34200000u
+
+// JPEG output and the strip buffer overlay demosbuf (460,800 B), which the
+// RAW path never touches (no WDMA3 write). Strip: Y 1280*16 + Cb/Cr 640*8*2.
+extern uint8_t demosbuf[];
+#define HIRES_STRIP_BYTES	((HIRES_WIDTH * 16u) + 2u * ((HIRES_WIDTH / 2u) * 8u))
+#define HIRES_JPEG_CAP		(460800u - HIRES_STRIP_BYTES)
+
+static bool active = false;
+
+static uint8_t *rawBuf(void)   { return &__tensor_arena_start__; }
+static uint8_t *jpegOut(void)  { return demosbuf; }
+static uint8_t *stripBuf(void) { return demosbuf + HIRES_JPEG_CAP; }
+
+bool hires_wanted(void) {
+#if defined(USE_RP2) || defined(USE_RP3)
+	if (fatfs_getOperationalParameter(OP_PARAMETER_CAM_RESOLUTION) != 1) {
+		return false;
+	}
+	if (cv_modelLoaded()) {
+		// The raw frame lives in the NN arena - the two are exclusive
+		xprintf("Hi-res: NN model loaded - falling back to 640x480 "
+				"(set op14 = 0 for high resolution)\n");
+		return false;
+	}
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool hires_isActive(void) {
+	return active;
+}
+
+int hires_datapath_init(void *cb_event) {
+	uint32_t rawStart = (uint32_t)rawBuf();
+	uint32_t rawEnd = rawStart + (HIRES_WIDTH * HIRES_HEIGHT);
+
+	if (rawEnd > SRAM_REGION_END) {
+		xprintf("Hi-res: raw buffer 0x%08x..0x%08x exceeds SRAM end - disabled\n",
+				(unsigned)rawStart, (unsigned)rawEnd);
+		return -1;
+	}
+
+	cisdp_set_hires_raw(rawStart);
+
+	// RAW path: INP centre-crop -> WDMA2. Same init call as the normal flow;
+	// the hires override (registered above) redirects geometry and target.
+	if (cisdp_dp_init(true, SENSORDPLIB_PATH_INP_WDMA2,
+					  (sensordplib_CBEvent_t)cb_event, 4,
+					  APP_DP_RES_YUV640x480_INP_SUBSAMPLE_1X) < 0) {
+		xprintf("Hi-res: RAW datapath init failed\n");
+		cisdp_set_hires_raw(0);
+		return -1;
+	}
+
+	active = true;
+	xprintf("Hi-res capture active: %ux%u RAW -> CPU pipeline (raw @0x%08x, "
+			"jpeg cap %u)\n", (unsigned)HIRES_WIDTH, (unsigned)HIRES_HEIGHT,
+			(unsigned)rawStart, (unsigned)HIRES_JPEG_CAP);
+	return 0;
+}
+
+void hires_deactivate(void) {
+	active = false;
+	cisdp_set_hires_raw(0);
+}
+
+uint32_t hires_process_frame(void) {
+	if (!active) {
+		return 0;
+	}
+
+	const uint8_t *raw = rawBuf();
+	uint32_t start = xTaskGetTickCount();
+
+	// The frame was DMA-written: refresh the CPU's view
+	SCB_InvalidateDCache_by_Addr((void *)raw, (int32_t)(HIRES_WIDTH * HIRES_HEIGHT));
+
+	demosaic_pattern_t pattern = (demosaic_pattern_t)cisdp_get_demos_pattern();
+
+	// Scene measurement straight off the Bayer plane: one AE step for the
+	// next frame, and this frame's uniform WB gains (no tile seams by
+	// construction - one gain pair for the whole image).
+	uint32_t rM, gM, bM, gP75;
+	demosaic_measure(raw, HIRES_WIDTH, HIRES_HEIGHT, pattern, &rM, &gM, &bM, &gP75);
+	ae_process_measured(gP75);
+
+	uint16_t rGain = 256, bGain = 256;
+	uint8_t wbMode = (uint8_t)fatfs_getOperationalParameter(OP_PARAMETER_CAM_WB_MODE);
+	if (wbMode == IMG_CORRECT_MODE_AUTO) {
+		if (!img_correct_gains_from_means(rM, gM, bM, &rGain, &bGain)) {
+			// too dark to trust - fall back to the manual gains
+			wbMode = IMG_CORRECT_MODE_MANUAL;
+		}
+	}
+	if (wbMode == IMG_CORRECT_MODE_MANUAL) {
+		rGain = (uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_RED_GAIN);
+		bGain = (uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN);
+		if (rGain == 0 || bGain == 0) {
+			rGain = 256;
+			bGain = 256;
+		}
+	}
+
+	sw_jpeg_stream_t st;
+	if (sw_jpeg_stream_begin(&st, HIRES_WIDTH, HIRES_HEIGHT,
+							 jpegOut(), HIRES_JPEG_CAP, HIRES_JPEG_QUALITY) != 0) {
+		return 0;
+	}
+
+	for (uint32_t row = 0; row < HIRES_HEIGHT; row += 16) {
+		demosaic_strip_yuv420(raw, HIRES_WIDTH, HIRES_HEIGHT, row, pattern,
+							  rGain, bGain, stripBuf());
+		if (sw_jpeg_stream_strip(&st, stripBuf()) != 0) {
+			xprintf("Hi-res: JPEG overflow at row %u (cap %u)\n",
+					(unsigned)row, (unsigned)HIRES_JPEG_CAP);
+			return 0;
+		}
+	}
+
+	uint32_t size = sw_jpeg_stream_end(&st);
+	if (size == 0) {
+		return 0;
+	}
+
+	// The JPEG was CPU-written: flush so later cache-invalidate readers and
+	// the FatFS/preview paths see the real bytes
+	SCB_CleanDCache_by_Addr((void *)jpegOut(), (int32_t)size);
+
+	// Hand the JPEG to the normal save/preview flow
+	img_correct_set_external_jpeg(size, (uint32_t)jpegOut());
+
+	xprintf("Hi-res: %ux%u JPEG %u bytes in %ums (WB R x%u/256 B x%u/256)\n",
+			(unsigned)HIRES_WIDTH, (unsigned)HIRES_HEIGHT, (unsigned)size,
+			(unsigned)((xTaskGetTickCount() - start) * portTICK_PERIOD_MS),
+			(unsigned)rGain, (unsigned)bGain);
+
+	return size;
+}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hires.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hires.h
@@ -1,0 +1,70 @@
+/*
+ * hires.h
+ *
+ * Single-file 1280x960 capture for the RP camera ("Option B" - see
+ * _Documentation/hires-capture.md).
+ *
+ * The WE2's hardware JPEG encoder and HW5x5 demosaic top out at 640x480,
+ * which is why Himax's suggested workaround splits a 1280x960 raw frame
+ * into four 640x480 JPEGs. This module instead captures the RAW Bayer
+ * frame (INP centre-crop of the sensor's 2304x1296 stream) and runs the
+ * whole pipeline on the CPU in 16-row strips: bilinear demosaic ->
+ * black level -> auto WB -> CCM -> gamma -> streaming software JPEG.
+ * Result: ONE JPEG, one EXIF block, no tile seams, no server-side
+ * stitching - at ~2-3 s per capture.
+ *
+ * Memory (all within existing regions, checked at runtime):
+ *   raw frame 1,228,800 B  -> overlays the (NN-idle) tensor arena + the
+ *                             free SRAM tail after it
+ *   JPEG out + strip buffer -> overlay demosbuf (unused: no WDMA3 here)
+ * High-resolution capture therefore REQUIRES the NN to be disabled
+ * (op14 = 0), matching the "trail-cam without NN" use case.
+ *
+ * Selected per wake via OP_PARAMETER_CAM_RESOLUTION (op32): 0 = 640x480
+ * (normal integrated pipeline), 1 = 1280x960 via this module.
+ */
+
+#ifndef HIRES_H_
+#define HIRES_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#define HIRES_WIDTH		1280u
+#define HIRES_HEIGHT	960u
+
+/**
+ * True when high-resolution capture can run: op32 selects it, the camera
+ * is an RP colour camera, and the NN is not loaded (its arena holds the
+ * raw frame).
+ */
+bool hires_wanted(void);
+
+/**
+ * True after hires_datapath_init() succeeded - the current datapath is the
+ * RAW capture path and FRAME_READY events carry a raw Bayer frame.
+ */
+bool hires_isActive(void);
+
+/**
+ * Configure the RAW datapath (call in place of the normal cisdp_dp_init()
+ * flow, before the sensor starts). Verifies the buffer layout fits.
+ * @return 0 on success
+ */
+int hires_datapath_init(void *cb_event);
+
+/**
+ * Deactivate (restores the normal WDMA2 binding for the next init).
+ */
+void hires_deactivate(void);
+
+/**
+ * Process the raw frame just captured: measure (AE step + auto WB gains),
+ * demosaic + colour-correct + JPEG-encode in strips, and register the
+ * result via img_correct_set_external_jpeg() so prepareJpegFile() and the
+ * live preview pick it up unchanged.
+ * @return JPEG size in bytes, 0 on failure
+ */
+uint32_t hires_process_frame(void);
+
+#endif /* HIRES_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hm0360_md.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hm0360_md.c
@@ -816,3 +816,115 @@ HX_CIS_ERROR_E hm0360_md_reInitialise(void) {
 
 	return ret;
 }
+
+/*
+ * ============================================================================
+ * Motion-detection instrumentation (Phase 0)
+ *
+ * Debug/characterisation helpers behind the `md` CLI command. They let a bench
+ * harness read and write any HM0360 register (with the main-camera I2C slave-ID
+ * swap) and snapshot the tunable MD registers, so the reference-init values can
+ * be characterised against real targets/noise before presets are chosen.
+ * See doc/Motion_detection_presets.md.
+ * ============================================================================
+ */
+
+/**
+ * Read one HM0360 register. Instrumentation only.
+ *
+ * @param addr - HM0360 register address
+ * @param val  - out; register value on success
+ * @return error code
+ */
+HX_CIS_ERROR_E hm0360_md_readReg(uint16_t addr, uint8_t *val) {
+	HX_CIS_ERROR_E ret;
+
+	if (!hm0360_present || (val == NULL)) {
+		return HX_CIS_UNKNOWN_ERROR;
+	}
+
+	saveMainCameraConfig();
+	ret = hx_drv_cis_get_reg(addr, val);
+	restoreMainCameraConfig();
+
+	return ret;
+}
+
+/**
+ * Write one HM0360 register. Instrumentation only.
+ *
+ * WARNING: writing MD registers while the sensor is streaming can disrupt the
+ * vision pipeline. A register sweep should quiesce the sensor first (see
+ * hm0360_md_setMode() / MODE_SLEEP). This raw writer does not, by design, so the
+ * caller controls sequencing.
+ *
+ * @param addr - HM0360 register address
+ * @param val  - value to write
+ * @return error code
+ */
+HX_CIS_ERROR_E hm0360_md_writeReg(uint16_t addr, uint8_t val) {
+	HX_CIS_ERROR_E ret;
+
+	if (!hm0360_present) {
+		return HX_CIS_UNKNOWN_ERROR;
+	}
+
+	saveMainCameraConfig();
+	ret = hx_drv_cis_set_reg(addr, val, 0);
+	restoreMainCameraConfig();
+
+	return ret;
+}
+
+/**
+ * Print the tunable motion-detection registers to the console for bench
+ * characterisation. Names + addresses per hm0360_regs.h; the WW500 MD path uses
+ * Context B. The semantics of MD_IIR_PARAM and the MD_LATENCY_TH nibbles are
+ * inferred from the reference init (no HM0360 datasheet exists) - confirm on the
+ * bench. See doc/Motion_detection_presets.md.
+ */
+void hm0360_md_dumpConfig(void) {
+	static const struct {
+		const char * name;
+		uint16_t     addr;
+	} mdRegs[] = {
+		{"MD_CTRL",           MD_CTRL},            // [0]=enable, [5:4]=latency select
+		{"MD_TH_MIN",         MD_TH_MIN},
+		{"MD_LIGHT_COEF",     MD_LIGHT_COEF},
+		{"MD_IIR_PARAM",      MD_IIR_PARAM},       // background-model IIR (semantics TBC)
+		{"MD_BLOCK_NUM_TH",   MD_BLOCK_NUM_TH},    // blocks-to-fire (cluster/target size)
+		{"MD_LATENCY",        MD_LATENCY},
+		{"MD_LATENCY_TH",     MD_LATENCY_TH},      // [7:4]=set, [3:0]=clear (persistence)
+		{"MD_CTRL1",          MD_CTRL1},
+		{"MD_TH_STR_L_B",     MD_TH_STR_L_B},      // per-block change threshold (Context B)
+		{"MD_TH_STR_H_B",     MD_TH_STR_H_B},
+		{"MD_CTRL_B",         MD_CTRL_B},
+		{"MD_BLOCK_NUM_TH_B", MD_BLOCK_NUM_TH_B},
+		{"ROI_V_B",           ROI_START_END_V_B},  // [7:4]=end, [3:0]=start (16-block grid)
+		{"ROI_H_B",           ROI_START_END_H_B},
+		{"PMU_CFG_7_nFrames", PMU_CFG_7},
+		{"PMU_CFG_8_dtHi",    PMU_CFG_8},          // sleep-count MSB = inter-sample interval
+		{"PMU_CFG_9_dtLo",    PMU_CFG_9},          // sleep-count LSB
+	};
+
+	uint8_t val;
+
+	if (!hm0360_present) {
+		xprintf("MD dump: HM0360 not present\n");
+		return;
+	}
+
+	saveMainCameraConfig();
+	xprintf("HM0360 MD registers (Context B = WW500 MD path):\n");
+	for (uint16_t i = 0; i < (sizeof(mdRegs) / sizeof(mdRegs[0])); i++) {
+		// Fixed-width addr/value columns (name trailing) - avoids %-Ns, which not
+		// all xprintf builds support; addr + value stay aligned regardless.
+		if (hx_drv_cis_get_reg(mdRegs[i].addr, &val) == HX_CIS_NO_ERROR) {
+			xprintf("  0x%04x = 0x%02x  %s\n", mdRegs[i].addr, val, mdRegs[i].name);
+		}
+		else {
+			xprintf("  0x%04x = ??    %s\n", mdRegs[i].addr, mdRegs[i].name);
+		}
+	}
+	restoreMainCameraConfig();
+}

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hm0360_md.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/hm0360_md.h
@@ -110,4 +110,12 @@ HX_CIS_ERROR_E hm0360_md_reInitialise(void);
 // Replaced by hm0360_md_prepare()
 //HX_CIS_ERROR_E hm0360_md_enableMD(uint16_t mdFrameInterval);
 
+// Motion-detection instrumentation (Phase 0 - see doc/Motion_detection_presets.md).
+// Debug/characterisation helpers behind the `md` CLI command: read/write any
+// HM0360 register (with the main-camera I2C slave-ID swap) and dump the tunable
+// MD registers to the console for the register-sweep harness.
+HX_CIS_ERROR_E hm0360_md_readReg(uint16_t addr, uint8_t *val);
+HX_CIS_ERROR_E hm0360_md_writeReg(uint16_t addr, uint8_t val);
+void hm0360_md_dumpConfig(void);
+
 #endif /* HM0360_MD_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
@@ -81,6 +81,7 @@
 #include "img_correct.h"
 #include "preview.h"
 #include "ae.h"
+#include "hires.h"
 
 /*************************************** Definitions *******************************************/
 
@@ -951,8 +952,9 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
 
 #if defined(USE_RP2) || defined(USE_RP3)
         // Auto-exposure for the RP camera (raw sensor, no on-sensor AE - see
-        // ae.c). Adjusts exposure/gain registers for the NEXT frame.
-        if (!aeCheckOnlyWake) {
+        // ae.c). Adjusts exposure/gain registers for the NEXT frame. In
+        // hi-res mode hires.c measures the raw Bayer frame itself.
+        if (!aeCheckOnlyWake && !hires_isActive()) {
         	ae_process(app_get_raw_addr(),
         			(uint16_t)app_get_raw_width(), (uint16_t)app_get_raw_height());
         }
@@ -971,7 +973,11 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
         	xprintf("Skipping file save.\n");
 
 #if defined(USE_RP2) || defined(USE_RP3)
-        	if (previewFrame) {
+        	if (hires_isActive()) {
+        		// Hi-res: CPU demosaic + colour + JPEG from the raw frame
+        		hires_process_frame();
+        	}
+        	else if (previewFrame) {
         		// The preview must show what a saved file would look like, so run
         		// the same software white-balance correction the save path runs
         		img_correct_process_mode(
@@ -991,11 +997,17 @@ static APP_MSG_DEST_T handleEventForCapturing(APP_MSG_T img_recv_msg) {
         	// green. Correct the YUV frame in software and re-encode it with a
         	// software JPEG encoder (sw_jpeg.c); prepareJpegFile() then uses the corrected
         	// JPEG. Mode op31: 0 = off, 1 = auto grey-world, 2 = manual op27/op28.
-        	img_correct_process_mode(
-        			(uint8_t)fatfs_getOperationalParameter(OP_PARAMETER_CAM_WB_MODE),
-        			(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_RED_GAIN),
-        			(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN),
-        			ledFlashIsActive());
+        	// In hi-res mode (op32) the whole pipeline runs in hires.c instead.
+        	if (hires_isActive()) {
+        		hires_process_frame();
+        	}
+        	else {
+        		img_correct_process_mode(
+        				(uint8_t)fatfs_getOperationalParameter(OP_PARAMETER_CAM_WB_MODE),
+        				(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_RED_GAIN),
+        				(uint16_t)fatfs_getOperationalParameter(OP_PARAMETER_WB_BLUE_GAIN),
+        				ledFlashIsActive());
+        	}
 #endif // USE_RP2 || USE_RP3
 
 #ifdef INVESTIGATE_BMP
@@ -1890,14 +1902,35 @@ static bool configure_image_sensor(CAMERA_CONFIG_E operation) {
         	// Sensor registers just reverted to the tables (+ staged file):
         	// restart the auto-exposure loop from the table values (ae.c)
         	ae_notifySensorInit();
-#endif // USE_RP2 || USE_RP3
 
+        	// High-resolution single-JPEG capture (op32 = 1, NN off): the
+        	// datapath becomes INP centre-crop -> RAW -> WDMA2 and the CPU
+        	// does demosaic/colour/JPEG in strips (hires.c). Selected here,
+        	// before the sensor starts - the datapath cannot be switched
+        	// mid-stream (see RP3_white_balance_reencode_issue.md).
+        	if (hires_wanted()) {
+        		if (hires_datapath_init((void *)os_app_dplib_cb) < 0) {
+        			xprintf("\r\nDATAPATH Init fail (hi-res)\r\n");
+        			return false;
+        		}
+        	}
+        	else {
+        		hires_deactivate();
+        		// if wdma variable is zero when not init yet, then this step is a must be to retrieve wdma address
+        		//  Datapath events give callbacks to os_app_dplib_cb()
+        		if (cisdp_dp_init(true, SENSORDPLIB_PATH_INT_INP_HW5X5_JPEG, os_app_dplib_cb, g_jpg_ratio, APP_DP_RES_YUV640x480_INP_SUBSAMPLE_1X) < 0) {
+        			xprintf("\r\nDATAPATH Init fail\r\n");
+        			return false;
+        		}
+        	}
+#else
         	// if wdma variable is zero when not init yet, then this step is a must be to retrieve wdma address
         	//  Datapath events give callbacks to os_app_dplib_cb()
         	if (cisdp_dp_init(true, SENSORDPLIB_PATH_INT_INP_HW5X5_JPEG, os_app_dplib_cb, g_jpg_ratio, APP_DP_RES_YUV640x480_INP_SUBSAMPLE_1X) < 0) {
         		xprintf("\r\nDATAPATH Init fail\r\n");
         		return false;
         	}
+#endif // USE_RP2 || USE_RP3
             setupLEDFlash();
 
         }
@@ -2116,8 +2149,14 @@ static void prepareJpegFile(int8_t * outCategories, uint8_t classCount, fileBuff
 	static uint8_t nnData[MAX_CLASSES + 2];
 	char deployment_id[UUIDLENGTH];
 
-	exif_input.width  = (uint16_t)app_get_raw_width();
-	exif_input.height = (uint16_t)app_get_raw_height();
+	if (hires_isActive()) {
+		exif_input.width  = (uint16_t)HIRES_WIDTH;
+		exif_input.height = (uint16_t)HIRES_HEIGHT;
+	}
+	else {
+		exif_input.width  = (uint16_t)app_get_raw_width();
+		exif_input.height = (uint16_t)app_get_raw_height();
+	}
 	exif_utc_get_rtc_as_exif_string(exif_input.timestamp, sizeof(exif_input.timestamp));
 
 	/* Camera identity, build provenance and flash state. The Model string names

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c
@@ -1697,6 +1697,10 @@ static void vImageTask(void *pvParameters) {
 
     if (interval > 0) {
     	xprintf("  MD sampling: %dms.\n", interval);
+    	if (fatfs_getOperationalParameter(OP_PARAMETER_MD_BLOCK_NUM_MAX) > 0) {
+    		xprintf("  MD global-motion limit: %d blocks (op33).\n",
+    				fatfs_getOperationalParameter(OP_PARAMETER_MD_BLOCK_NUM_MAX));
+    	}
     }
     else {
     	xprintf("  MD disabled.\n");
@@ -1711,12 +1715,47 @@ static void vImageTask(void *pvParameters) {
 
     XP_WHITE;
 
+    // ── Global-motion rejection (false-trigger filter) ──────────────────────
+    // A knocked/panned camera or a scene-wide lighting change moves MOST of the
+    // 16x16 MD grid at once; an animal moves a small local cluster. On an MD
+    // wake, when OP_PARAMETER_MD_BLOCK_NUM_MAX > 0, read the motion bitmap that
+    // caused the wake (still held in the HM0360 MD_ROI_OUT registers - the
+    // interrupt clear is deferred to first FRAME_READY) and skip the capture
+    // when more blocks moved than the limit. The wake itself cannot be
+    // prevented (the sensor has a minimum-blocks trigger, MD_BLOCK_NUM_TH, but
+    // no maximum); this stops the false capture/save/upload that would follow.
+    bool mdWakeRejected = false;
+    if ((woken == APP_WAKE_REASON_MD) && cameraInitialised) {
+        uint16_t mdBlocksMax = fatfs_getOperationalParameter(OP_PARAMETER_MD_BLOCK_NUM_MAX);
+        if (mdBlocksMax > 0) {
+            uint8_t roiOut[ROIOUTENTRIES];
+            uint16_t mdBlocks = hm0360_md_getMDOutput(roiOut, ROIOUTENTRIES);
+            if (mdBlocks > mdBlocksMax) {
+                mdWakeRejected = true;
+                // The deferred clear at FRAME_READY will not run - clear here so
+                // the stale trigger cannot re-fire (the sleep path clears again).
+                hm0360_md_clearInterrupt(0xff);
+                snprintf(msgToMaster, MSGTOMASTERLEN,
+                        "MD wake rejected: motion in %d blocks > max %d (global motion)",
+                        mdBlocks, mdBlocksMax);
+                XP_YELLOW;
+                xprintf("%s\n", msgToMaster);
+                XP_WHITE;
+                sendMsgToMaster(msgToMaster);   // let the BLE app show the rejection
+            }
+            else {
+                xprintf("MD wake accepted: motion in %d blocks (max %d)\n", mdBlocks, mdBlocksMax);
+            }
+        }
+    }
+
     // If we woke because of motion detection or timer then let's send ourselves an initial
     // message to take some photos.
 
     // But only if nnSystemEnabled and cameraInitialised!
 
-    if ((cameraSystemEnabled == 1)  && cameraInitialised && ((woken == APP_WAKE_REASON_MD) || (woken == APP_WAKE_REASON_TIMER))) {
+    if ((cameraSystemEnabled == 1)  && cameraInitialised && !mdWakeRejected
+    		&& ((woken == APP_WAKE_REASON_MD) || (woken == APP_WAKE_REASON_TIMER))) {
 
     	// A timer wake with timelapse disabled and a light-decision consumer
     	// enabled (AE-driven flash, or automatic camera switching op26) is a

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.c
@@ -146,29 +146,8 @@ static void wb_apply_yuv420(uint8_t *yuv, uint32_t w, uint32_t h,
 				if (G < 0) G = 0; else if (G > 255) G = 255;
 				if (B < 0) B = 0; else if (B > 255) B = 255;
 
-				// Black level: subtract the sensor pedestal, restore range
-				R = (R > BLACK_LEVEL) ? (((R - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
-				G = (G > BLACK_LEVEL) ? (((G - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
-				B = (B > BLACK_LEVEL) ? (((B - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
-
-				// White balance: scale red and blue (green is the reference)
-				R = (R * rGain) >> 8;
-				B = (B * bGain) >> 8;
-				if (R > 255) R = 255;
-				if (B > 255) B = 255;
-
-				// Colour correction matrix (4640 K, Q8.8)
-				int32_t Rc = (CCM_Q8[0] * R + CCM_Q8[1] * G + CCM_Q8[2] * B) >> 8;
-				int32_t Gc = (CCM_Q8[3] * R + CCM_Q8[4] * G + CCM_Q8[5] * B) >> 8;
-				int32_t Bc = (CCM_Q8[6] * R + CCM_Q8[7] * G + CCM_Q8[8] * B) >> 8;
-				if (Rc < 0) Rc = 0; else if (Rc > 255) Rc = 255;
-				if (Gc < 0) Gc = 0; else if (Gc > 255) Gc = 255;
-				if (Bc < 0) Bc = 0; else if (Bc > 255) Bc = 255;
-
-				// Tone curve
-				R = GAMMA_LUT[Rc];
-				G = GAMMA_LUT[Gc];
-				B = GAMMA_LUT[Bc];
+				// Black level -> WB gains -> CCM -> gamma (shared transform)
+				img_correct_transform_rgb(&R, &G, &B, rGain, bGain);
 
 				// Back to YCbCr (JPEG full range)
 				int32_t newY = (77 * R + 150 * G + 29 * B) >> 8;
@@ -187,6 +166,37 @@ static void wb_apply_yuv420(uint8_t *yuv, uint32_t w, uint32_t h,
 			v[cx] = (uint8_t)newCr;
 		}
 	}
+}
+
+/*************************************** Shared colour transform *************/
+
+void img_correct_transform_rgb(int32_t *r, int32_t *g, int32_t *b,
+							   uint16_t rGainQ8, uint16_t bGainQ8) {
+	int32_t R = *r, G = *g, B = *b;
+
+	// Black level: subtract the sensor pedestal, restore range
+	R = (R > BLACK_LEVEL) ? (((R - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+	G = (G > BLACK_LEVEL) ? (((G - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+	B = (B > BLACK_LEVEL) ? (((B - BLACK_LEVEL) * BLACK_RESCALE_Q8) >> 8) : 0;
+
+	// White balance: scale red and blue (green is the reference)
+	R = (R * rGainQ8) >> 8;
+	B = (B * bGainQ8) >> 8;
+	if (R > 255) R = 255;
+	if (B > 255) B = 255;
+
+	// Colour correction matrix (4640 K, Q8.8)
+	int32_t Rc = (CCM_Q8[0] * R + CCM_Q8[1] * G + CCM_Q8[2] * B) >> 8;
+	int32_t Gc = (CCM_Q8[3] * R + CCM_Q8[4] * G + CCM_Q8[5] * B) >> 8;
+	int32_t Bc = (CCM_Q8[6] * R + CCM_Q8[7] * G + CCM_Q8[8] * B) >> 8;
+	if (Rc < 0) Rc = 0; else if (Rc > 255) Rc = 255;
+	if (Gc < 0) Gc = 0; else if (Gc > 255) Gc = 255;
+	if (Bc < 0) Bc = 0; else if (Bc > 255) Bc = 255;
+
+	// Tone curve
+	*r = GAMMA_LUT[Rc];
+	*g = GAMMA_LUT[Gc];
+	*b = GAMMA_LUT[Bc];
 }
 
 /*************************************** Auto white balance ******************/
@@ -242,19 +252,12 @@ static void wb_measure_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
 	*bMean = bSum / n;
 }
 
-/**
- * Compute warmth-biased grey-world gains for the current frame.
- * Returns false if the frame is too dark to measure reliably.
- */
-static bool wb_auto_gains(const uint8_t *yuv, uint32_t w, uint32_t h,
-						  uint16_t *rGainQ8, uint16_t *bGainQ8) {
-	uint32_t rM, gM, bM;
-	wb_measure_yuv420(yuv, w, h, &rM, &gM, &bM);
-
+bool img_correct_gains_from_means(uint32_t rMean, uint32_t gMean, uint32_t bMean,
+								  uint16_t *rGainQ8, uint16_t *bGainQ8) {
 	// Pedestal-correct; if the scene is essentially black, don't guess
-	rM = (rM > WB_AUTO_PEDESTAL) ? (rM - WB_AUTO_PEDESTAL) : 0;
-	gM = (gM > WB_AUTO_PEDESTAL) ? (gM - WB_AUTO_PEDESTAL) : 0;
-	bM = (bM > WB_AUTO_PEDESTAL) ? (bM - WB_AUTO_PEDESTAL) : 0;
+	uint32_t rM = (rMean > WB_AUTO_PEDESTAL) ? (rMean - WB_AUTO_PEDESTAL) : 0;
+	uint32_t gM = (gMean > WB_AUTO_PEDESTAL) ? (gMean - WB_AUTO_PEDESTAL) : 0;
+	uint32_t bM = (bMean > WB_AUTO_PEDESTAL) ? (bMean - WB_AUTO_PEDESTAL) : 0;
 	if ((gM < 4) || (rM < 2) || (bM < 2)) {
 		return false;
 	}
@@ -273,6 +276,17 @@ static bool wb_auto_gains(const uint8_t *yuv, uint32_t w, uint32_t h,
 	*rGainQ8 = (uint16_t)rGain;
 	*bGainQ8 = (uint16_t)bGain;
 	return true;
+}
+
+/**
+ * Compute warmth-biased grey-world gains for the current frame.
+ * Returns false if the frame is too dark to measure reliably.
+ */
+static bool wb_auto_gains(const uint8_t *yuv, uint32_t w, uint32_t h,
+						  uint16_t *rGainQ8, uint16_t *bGainQ8) {
+	uint32_t rM, gM, bM;
+	wb_measure_yuv420(yuv, w, h, &rM, &gM, &bM);
+	return img_correct_gains_from_means(rM, gM, bM, rGainQ8, bGainQ8);
 }
 
 /*************************************** Public API **************************/
@@ -365,4 +379,10 @@ void img_correct_get_jpeg(uint32_t *size, uint32_t *addr) {
 		*size = corrected_size;
 		*addr = corrected_addr;
 	}
+}
+
+void img_correct_set_external_jpeg(uint32_t size, uint32_t addr) {
+	corrected_valid = (size > 0) && (addr != 0);
+	corrected_size = size;
+	corrected_addr = addr;
 }

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/img_correct.h
@@ -71,4 +71,26 @@ bool img_correct_process_mode(uint8_t mode, uint16_t rManualQ8, uint16_t bManual
  */
 void img_correct_get_jpeg(uint32_t *size, uint32_t *addr);
 
+/**
+ * Register an externally produced JPEG (e.g. the high-resolution capture in
+ * hires.c) so prepareJpegFile() picks it up exactly like a corrected frame.
+ */
+void img_correct_set_external_jpeg(uint32_t size, uint32_t addr);
+
+/**
+ * The shared per-pixel colour transform: black level -> WB gains -> CCM ->
+ * gamma. r/g/b are 0..255 in and out. Used by the VGA correction pass and
+ * the high-resolution demosaic (one definition so the two paths cannot
+ * drift apart).
+ */
+void img_correct_transform_rgb(int32_t *r, int32_t *g, int32_t *b,
+							   uint16_t rGainQ8, uint16_t bGainQ8);
+
+/**
+ * Warmth-biased grey-world gains from measured channel means (pedestal is
+ * subtracted here). Returns false if the scene is too dark to trust.
+ */
+bool img_correct_gains_from_means(uint32_t rMean, uint32_t gMean, uint32_t bMean,
+								  uint16_t *rGainQ8, uint16_t *bGainQ8);
+
 #endif /* IMG_CORRECT_H_ */

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
@@ -33,9 +33,10 @@
 #include "img_correct.h"	// img_correct_get_jpeg()
 #include "preview.h"
 
-// A VGA JPEG should be well under this; anything bigger means the JPEG
-// info is implausible and the frame is skipped rather than streamed.
-#define PREVIEW_MAX_JPEG_BYTES	(200 * 1024)
+// A VGA JPEG is well under 200 KB and a 1280x960 hi-res JPEG (hires.c)
+// under ~400 KB; anything bigger means the JPEG info is implausible and
+// the frame is skipped rather than streamed.
+#define PREVIEW_MAX_JPEG_BYTES	(420 * 1024)
 
 // Base64 input chunk. Must be a multiple of 3 so '=' padding can only
 // occur at the very end of the frame.

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c
@@ -7,7 +7,13 @@
  * Frame line format (one line per frame, CR ... LF):
  *
  *   {"type": 1, "name": "INVOKE", "code": 0, "data": {"count": N,
- *    "resolution": [W, H], "boxes": [], "image": "<base64 JPEG>"}}
+ *    "resolution": [W, H], "boxes": [], "md_blocks": M, "md": "<64 hex>",
+ *    "image": "<base64 JPEG>"}}
+ *
+ * "md" is the HM0360 16x16 motion grid (32 MD_ROI_OUT bytes as hex, LSB-first
+ * within each byte) and "md_blocks" the count of blocks flagged as moving, so a
+ * viewer can overlay a motion heatmap on the live image. Both are omitted-safe:
+ * older/other viewers ignore the extra fields.
  *
  * This is the same framing the Himax/SSCMA scenario apps use (see
  * app/scenario_app/tflm_fd_fm/send_result.cpp), so as well as
@@ -32,6 +38,9 @@
 #include "cisdp_sensor.h"	// cisdp_get_jpginfo(), app_get_raw_width/height()
 #include "img_correct.h"	// img_correct_get_jpeg()
 #include "preview.h"
+#include "hm0360_md.h"		// hm0360_md_getMDOutput(), hm0360_md_prepare()
+#include "hm0360_regs.h"	// ROIOUTENTRIES (the 32 MD_ROI_OUT registers)
+#include "fatfs_task.h"		// fatfs_getOperationalParameter(OP_PARAMETER_MD_INTERVAL)
 
 // A VGA JPEG is well under 200 KB and a 1280x960 hi-res JPEG (hires.c)
 // under ~400 KB; anything bigger means the JPEG info is implausible and
@@ -45,6 +54,18 @@
 static volatile PREVIEW_MODE_E previewMode = PREVIEW_OFF;
 static uint32_t frameCount = 0;
 
+// While previewing, the HM0360 MD engine is armed to run concurrently with the
+// main-camera stream (hm0360_md_prepare(true,...)), so each frame can carry a
+// fresh motion grid for the viewer to overlay. Armed lazily on the first
+// streamed frame - in preview_sendFrame(), which runs in the image-task context
+// where the HM0360 I2C slave-swap inside getMDOutput()/prepare() is safe - and
+// re-armed whenever preview is toggled off then on again.
+static bool mdArmedForPreview = false;
+
+// Fallback MD frame interval (ms) when OP_PARAMETER_MD_INTERVAL is 0 (i.e. field
+// motion detection is disabled but we still want a live grid while previewing).
+#define PREVIEW_MD_DEFAULT_INTERVAL_MS	100
+
 static const char BASE64_CHARS[] =
 		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
@@ -52,6 +73,7 @@ void preview_setMode(PREVIEW_MODE_E mode) {
 	previewMode = mode;
 	if (mode == PREVIEW_OFF) {
 		frameCount = 0;
+		mdArmedForPreview = false;	// re-arm MD next time preview starts
 	}
 }
 
@@ -134,10 +156,41 @@ void preview_sendFrame(void) {
 
 	frameCount++;
 
+	// Arm the HM0360 MD engine to run alongside the preview stream (once per
+	// preview session). cameraSystemEnabled=true keeps MD running while the SoC
+	// is awake - the normal firmware only arms MD on the sleep path, which is
+	// why the grid reads empty during an ordinary awake capture.
+	if (!mdArmedForPreview) {
+		uint16_t mdInterval = fatfs_getOperationalParameter(OP_PARAMETER_MD_INTERVAL);
+		if (mdInterval == 0) {
+			mdInterval = PREVIEW_MD_DEFAULT_INTERVAL_MS;
+		}
+		hm0360_md_prepare(true, mdInterval);
+		mdArmedForPreview = true;
+	}
+
+	// Read the 16x16 motion grid (32 MD_ROI_OUT bytes) and render it as hex.
+	// getMDOutput() does its own main-camera I2C slave-swap, so it is safe to
+	// call here after the frame's own capture has completed.
+	uint8_t roiOut[ROIOUTENTRIES];
+	uint16_t mdBlocks = hm0360_md_getMDOutput(roiOut, ROIOUTENTRIES);
+	static const char HEXDIGIT[] = "0123456789abcdef";
+	char mdHex[(ROIOUTENTRIES * 2) + 1];
+	for (uint8_t i = 0; i < ROIOUTENTRIES; i++) {
+		mdHex[(i * 2)]     = HEXDIGIT[(roiOut[i] >> 4) & 0x0f];
+		mdHex[(i * 2) + 1] = HEXDIGIT[roiOut[i] & 0x0f];
+	}
+	mdHex[ROIOUTENTRIES * 2] = '\0';
+
+	// Frame line gains "md_blocks" (moving-block count) and "md" (64-hex-char
+	// 16x16 motion bitmap) beside the JPEG. Existing viewers (live_view.py, the
+	// Himax web toolkit) ignore the extra fields, so this stays compatible.
 	xprintf("\r{\"type\": 1, \"name\": \"INVOKE\", \"code\": 0, \"data\": {\"count\": %d, "
-			"\"resolution\": [%d, %d], \"boxes\": [], \"image\": \"",
+			"\"resolution\": [%d, %d], \"boxes\": [], \"md_blocks\": %d, \"md\": \"%s\", "
+			"\"image\": \"",
 			(int)frameCount,
-			(int)app_get_raw_width(), (int)app_get_raw_height());
+			(int)app_get_raw_width(), (int)app_get_raw_height(),
+			(int)mdBlocks, mdHex);
 
 	sendBase64((const uint8_t *)jpegBuffer, jpegLength);
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/sw_jpeg.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/sw_jpeg.c
@@ -302,6 +302,8 @@ static void get_block(const uint8_t *plane, int stride, int W, int H,
     }
 }
 
+static void write_headers(bitwriter_t *bwp, uint32_t w, uint32_t h);
+
 uint32_t sw_jpeg_encode_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
                                uint8_t *out, uint32_t outCap, uint8_t quality) {
     if (!yuv || !out || w == 0 || h == 0 || (w & 1) || (h & 1)) {
@@ -320,7 +322,40 @@ uint32_t sw_jpeg_encode_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
     bitwriter_t bw = {0};
     bw.buf = out; bw.cap = outCap;
 
-    // ---- headers ----
+    write_headers(&bw, w, h);
+
+    // ---- scan: 16x16 MCUs, each 4 Y + 1 Cb + 1 Cr ----
+    int dcY = 0, dcCb = 0, dcCr = 0;
+    int mcuX = ((int)w + 15) / 16, mcuY = ((int)h + 15) / 16;
+    float blk[64];
+
+    for (int my = 0; my < mcuY && !bw.overflow; my++) {
+        for (int mx = 0; mx < mcuX; mx++) {
+            int bx = mx * 16, by = my * 16;
+            // 4 luma blocks: TL, TR, BL, BR
+            get_block(yP, (int)w, (int)w, (int)h, bx,     by,     blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
+            get_block(yP, (int)w, (int)w, (int)h, bx + 8, by,     blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
+            get_block(yP, (int)w, (int)w, (int)h, bx,     by + 8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
+            get_block(yP, (int)w, (int)w, (int)h, bx + 8, by + 8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
+            // chroma (downsampled): one 8x8 each at (mx*8, my*8)
+            get_block(cbP, cw, cw, ch, mx * 8, my * 8, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &dcCb);
+            get_block(crP, cw, cw, ch, mx * 8, my * 8, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &dcCr);
+        }
+    }
+
+    bw_flush(&bw);
+    bw_marker(&bw, 0xD9);                            // EOI
+
+    if (bw.overflow) return 0;
+    return bw.len;
+}
+
+/*
+ * Shared JFIF header writer (SOI .. SOS) used by both the whole-frame and
+ * streamed encoders. Tables must already be initialised for the quality.
+ */
+static void write_headers(bitwriter_t *bwp, uint32_t w, uint32_t h) {
+#define bw (*bwp)
     bw_marker(&bw, 0xD8);                          // SOI
 
     bw_marker(&bw, 0xE0);                           // APP0 / JFIF
@@ -359,29 +394,85 @@ uint32_t sw_jpeg_encode_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
     bw_byte(&bw, 0x02); bw_byte(&bw, 0x11);         // Cb : DC1 AC1
     bw_byte(&bw, 0x03); bw_byte(&bw, 0x11);         // Cr : DC1 AC1
     bw_byte(&bw, 0x00); bw_byte(&bw, 0x3F); bw_byte(&bw, 0x00);  // Ss Se Ah/Al
+#undef bw
+}
 
-    // ---- scan: 16x16 MCUs, each 4 Y + 1 Cb + 1 Cr ----
-    int dcY = 0, dcCb = 0, dcCr = 0;
-    int mcuX = ((int)w + 15) / 16, mcuY = ((int)h + 15) / 16;
-    float blk[64];
+/*************************************** Streaming API **********************/
 
-    for (int my = 0; my < mcuY && !bw.overflow; my++) {
-        for (int mx = 0; mx < mcuX; mx++) {
-            int bx = mx * 16, by = my * 16;
-            // 4 luma blocks: TL, TR, BL, BR
-            get_block(yP, (int)w, (int)w, (int)h, bx,     by,     blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
-            get_block(yP, (int)w, (int)w, (int)h, bx + 8, by,     blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
-            get_block(yP, (int)w, (int)w, (int)h, bx,     by + 8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
-            get_block(yP, (int)w, (int)w, (int)h, bx + 8, by + 8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &dcY);
-            // chroma (downsampled): one 8x8 each at (mx*8, my*8)
-            get_block(cbP, cw, cw, ch, mx * 8, my * 8, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &dcCb);
-            get_block(crP, cw, cw, ch, mx * 8, my * 8, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &dcCr);
-        }
+// Copy bitwriter state between the public stream struct and the internal
+// bitwriter (kept separate so the header stays free of internals).
+static void st_load(const sw_jpeg_stream_t *s, bitwriter_t *bw) {
+    bw->buf = s->buf;  bw->cap = s->cap;  bw->len = s->len;
+    bw->bitBuf = s->bits;  bw->bitCnt = s->nbits;  bw->overflow = s->overflow;
+}
+
+static void st_store(const bitwriter_t *bw, sw_jpeg_stream_t *s) {
+    s->len = bw->len;  s->bits = bw->bitBuf;
+    s->nbits = bw->bitCnt;  s->overflow = (uint8_t)bw->overflow;
+}
+
+int sw_jpeg_stream_begin(sw_jpeg_stream_t *s, uint32_t w, uint32_t h,
+                         uint8_t *out, uint32_t outCap, uint8_t quality) {
+    if (!s || !out || w == 0 || h == 0 || (w & 1)) {
+        return -1;
+    }
+    if (tablesReadyQuality != (int)quality) {
+        init_tables(quality);
+    }
+    memset(s, 0, sizeof(*s));
+    s->buf = out;
+    s->cap = outCap;
+    s->w = w;
+    s->h = h;
+
+    bitwriter_t bw = {0};
+    st_load(s, &bw);
+    write_headers(&bw, w, h);
+    st_store(&bw, s);
+    return 0;
+}
+
+int sw_jpeg_stream_strip(sw_jpeg_stream_t *s, const uint8_t *stripYuv) {
+    if (!s || !stripYuv || s->overflow || (s->rowsDone >= s->h)) {
+        return -1;
     }
 
+    const uint8_t *yP  = stripYuv;
+    const uint8_t *cbP = stripYuv + (s->w * 16u);
+    const uint8_t *crP = cbP + ((s->w / 2u) * 8u);
+    int w = (int)s->w;
+    int cw = w / 2;
+    int mcuX = (w + 15) / 16;
+    float blk[64];
+
+    bitwriter_t bw;
+    st_load(s, &bw);
+
+    for (int mx = 0; mx < mcuX && !bw.overflow; mx++) {
+        int bx = mx * 16;
+        // 4 luma blocks: TL, TR, BL, BR (strip-local coordinates, 16 rows)
+        get_block(yP, w, w, 16, bx,     0, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &s->dcY);
+        get_block(yP, w, w, 16, bx + 8, 0, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &s->dcY);
+        get_block(yP, w, w, 16, bx,     8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &s->dcY);
+        get_block(yP, w, w, 16, bx + 8, 8, blk); encode_block(&bw, blk, qLuma, &hDcLuma, &hAcLuma, &s->dcY);
+        // chroma (downsampled): one 8x8 each
+        get_block(cbP, cw, cw, 8, mx * 8, 0, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &s->dcCb);
+        get_block(crP, cw, cw, 8, mx * 8, 0, blk); encode_block(&bw, blk, qChroma, &hDcChroma, &hAcChroma, &s->dcCr);
+    }
+
+    st_store(&bw, s);
+    s->rowsDone += 16;
+    return s->overflow ? -1 : 0;
+}
+
+uint32_t sw_jpeg_stream_end(sw_jpeg_stream_t *s) {
+    if (!s || s->overflow || (s->rowsDone < s->h)) {
+        return 0;
+    }
+    bitwriter_t bw;
+    st_load(s, &bw);
     bw_flush(&bw);
     bw_marker(&bw, 0xD9);                            // EOI
-
-    if (bw.overflow) return 0;
-    return bw.len;
+    st_store(&bw, s);
+    return s->overflow ? 0 : s->len;
 }

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/sw_jpeg.h
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/sw_jpeg.h
@@ -34,4 +34,47 @@
 uint32_t sw_jpeg_encode_yuv420(const uint8_t *yuv, uint32_t w, uint32_t h,
                                uint8_t *out, uint32_t outCap, uint8_t quality);
 
+/*
+ * Streaming (strip) API - encode an image 16 luma rows at a time, so a
+ * frame larger than free SRAM never needs a full YUV buffer (used by the
+ * 1280x960 high-resolution capture, which demosaics the raw frame strip by
+ * strip). Produces a bitstream identical to sw_jpeg_encode_yuv420().
+ */
+
+typedef struct {
+	uint8_t  *buf;			// output buffer
+	uint32_t  cap;
+	uint32_t  len;
+	uint32_t  bits;			// bit accumulator (internal)
+	int       nbits;
+	uint8_t   overflow;
+	uint32_t  w, h;
+	uint32_t  rowsDone;		// luma rows consumed so far
+	int       dcY, dcCb, dcCr;	// DC predictors carried across strips
+} sw_jpeg_stream_t;
+
+/**
+ * Start a streamed encode: writes the JFIF headers for a w x h image.
+ * w must be a multiple of 2; strips are 16 luma rows each, so h is padded
+ * by replication in the final strip if not a multiple of 16.
+ * @return 0 on success, -1 on bad arguments
+ */
+int sw_jpeg_stream_begin(sw_jpeg_stream_t *s, uint32_t w, uint32_t h,
+                         uint8_t *out, uint32_t outCap, uint8_t quality);
+
+/**
+ * Encode the next strip of 16 luma rows. stripYuv is planar YUV420 local to
+ * the strip: Y (w*16), then Cb (w/2 * 8), then Cr (w/2 * 8). For the final
+ * strip of an image whose height is not a multiple of 16, fill the unused
+ * rows by replicating the last valid row.
+ * @return 0 on success, -1 if called past the image height or after overflow
+ */
+int sw_jpeg_stream_strip(sw_jpeg_stream_t *s, const uint8_t *stripYuv);
+
+/**
+ * Finish the stream (entropy flush + EOI).
+ * @return JPEG size in bytes, or 0 on overflow / incomplete image
+ */
+uint32_t sw_jpeg_stream_end(sw_jpeg_stream_t *s);
+
 #endif /* SW_JPEG_H_ */

--- a/_Documentation/Operational_Parameters.md
+++ b/_Documentation/Operational_Parameters.md
@@ -182,6 +182,7 @@ Those comments preceding the first index/value pair are preserved when the file 
 |    29 | OP_PARAMETER_CAM_AE_ENABLE 			| 1             | RP camera auto-exposure: 0 = off (init-table exposure), 1 = on. Highlight-metered loop steps sensor exposure (8-5000 lines) then analog gain (to 16x) toward the target - see `ae.c` |
 |    30 | OP_PARAMETER_CAM_AE_TARGET 			| 110           | Auto-exposure target: raw bright-quartile (p75) luma, 0-250 (0 = built-in default 95). Bright parts of the scene render just below white after the tone curve |
 |    31 | OP_PARAMETER_CAM_WB_MODE 				| 1             | RP camera white balance: 0 = off (hardware JPEG), 1 = auto (warmth-biased grey-world measured per frame), 2 = manual op27/op28. Auto falls back to manual for flash-lit or too-dark frames - see `img_correct.c` |
+|    32 | OP_PARAMETER_CAM_RESOLUTION 			| 0             | RP camera capture resolution: 0 = 640x480 (normal pipeline), 1 = 1280x960 single JPEG via the CPU pipeline - requires the NN off (op14 = 0); see [hires-capture.md](hires-capture.md) |
 
 
 ## Syncronisation with BLE Processor Code

--- a/_Documentation/hires-capture.md
+++ b/_Documentation/hires-capture.md
@@ -1,0 +1,80 @@
+# High-resolution capture — one 1280x960 JPEG (op32)
+
+#### Claude - 11 July 2026 (branch `feat/hires-capture`)
+
+## Why not the Himax 4-tile workaround
+
+The WE2's hardware JPEG encoder and HW5x5 demosaic top out at 640x480, so
+Himax's suggested route to higher resolution (Nov 2024 thread with Steve
+Huang; bench-validated by Tobyn via `allon_jpeg_encode`) captures one
+1280x960 RAW frame and splits it into **four** 640x480 JPEGs — which then
+need EXIF quadrant tagging, 4-files-per-capture handling on the SD and
+through upload, forced-uniform WB across tiles, and a server-side stitch
+job in the website.
+
+That workaround predates this firmware's **software JPEG encoder**
+(`sw_jpeg.c`, added for the white-balance work). The software encoder has
+no resolution limit, so the whole tiling problem disappears:
+
+```
+sensor 2304x1296 --INP centre-crop--> RAW Bayer 1280x960 -> WDMA2 (1.22 MB)
+     then on the CPU, 16 rows at a time:
+bilinear demosaic -> black level -> auto WB -> CCM -> gamma
+     -> streaming JPEG encode -> ONE ~200-300 KB file, ONE EXIF block
+```
+
+No seams (one WB gain pair per frame, by construction), no stitching
+anywhere, and the EXIF question from the email thread evaporates.
+
+Answers to the open questions in that thread, from the reference code:
+- `allon_jpeg_encode` takes **one** capture; the four JPEGs are quadrants
+  of the same instant (no time offsets).
+- Raw Bayer is 1 byte/pixel: a 1280x960 frame is 1.22 MB, not 2.4.
+
+## Memory (all within existing regions; checked at runtime)
+
+| Buffer | Size | Lives in |
+|---|---|---|
+| RAW Bayer frame | 1,228,800 B | tensor arena (512 KB, idle with NN off) + the free SRAM tail after it |
+| JPEG output | ~430 KB cap | `demosbuf` (idle: the RAW path never writes WDMA3) |
+| strip YUV (16 rows) | 30,720 B | `demosbuf`, after the JPEG area |
+
+**Hi-res therefore requires the NN to be off (op14 = 0)** — the raw frame
+occupies the NN arena. This matches the "trail-cam without NN" use case
+the resolution question came from. If a model is loaded, capture falls
+back to 640x480 with a console note.
+
+## Usage
+
+```
+setop 14 0        # NN off (frees the arena)
+setop 32 1        # 1280x960 single-JPEG mode  (0 = normal 640x480)
+reset             # datapath mode is chosen at sensor init, per wake
+```
+
+Everything else behaves identically: auto-exposure (measured from the raw
+green channel), auto white balance (measured from the raw Bayer means),
+EXIF (correct 1280x960 dimensions), SD save, and the live preview stream
+(~4 s/frame at this size). Field of view: the 1280x960 centre crop sees
+**twice the width and height** of the current 640x480 pipeline (which is
+also a centre crop of the same sensor stream).
+
+Capture cost: ~2-3 s per frame (CPU demosaic + colour + JPEG on the
+CM55M), so use generous capture intervals (`capture N 3000`).
+
+## Design notes
+
+- The RAW datapath is selected **from init, per wake** (op32 checked in
+  `CAMERA_CONFIG_INIT_COLD`) — the WE2 datapath cannot be reconfigured
+  mid-stream (see `RP3_white_balance_reencode_issue.md` §5).
+- `SENSORDPLIB_STATUS_XDMA_FRAME_READY` fires for the RAW path exactly as
+  for the integrated path (verified in `allon_jpeg_encode`), so the image
+  task's event flow is unchanged.
+- The streamed encoder is bit-exact with the whole-frame one (PC-verified
+  at 1280x960); DC predictors carry across strips.
+- The demosaic is bilinear (fused with the colour transform in one pass);
+  a sharper kernel (e.g. Malvar) can be swapped in later without touching
+  the API.
+- Files: `hires.c/h` (orchestration + buffer overlay), `demosaic.c/h`,
+  `sw_jpeg.c/h` (streaming API), `cisdp_sensor.c` (imx708: hires override),
+  `image_task.c` (mode selection + frame branch).

--- a/_Documentation/live_preview.md
+++ b/_Documentation/live_preview.md
@@ -38,8 +38,14 @@ streams Himax's own sensor init instead.
 ## The viewer: `_Tools/live_view.py`
 
 ```
-py _Tools\live_view.py            # defaults COM14, 921600
+py _Tools\live_view.py            # defaults COM13 (Himax), 921600
 ```
+
+> **Port:** the preview stream is emitted by the **Himax HX6538** console, which
+> is **COM13 @ 921600**. COM14 @ 115200 is the separate nRF52 BLE/LoRaWAN
+> co-processor (its console shows `Secure Bootloader`, `Initialising LoRaWAN`,
+> `AI processor sends stats: ...`) and carries no preview - don't point the
+> viewer there.
 
 Shows the live image plus a console log pane, a command box and quick-command
 buttons, so `setop 27 ...`, `setop 28 ...`, `vcm ...`, `camreg ...` can be
@@ -48,6 +54,28 @@ and automatically re-arms the capture burst when it runs out; "Stop stream"
 sends `preview 0`. "Save frame" writes the last JPEG to disk for A/B records.
 
 Close TeraTerm first - Windows COM ports are exclusive.
+
+## Motion-detection overlay (MD tuning)
+
+When the firmware is built with the MD-in-preview change (`preview.c` emits
+`"md"`/`"md_blocks"` in each frame), the viewer draws the HM0360 **16x16 motion
+grid** as a translucent red heatmap over the live image, and shows the
+moving-block count in the status panel. Toggle it with the **"MD motion
+overlay"** checkbox.
+
+This turns preview into a live MD-tuning bench: the sidebar has
+`camreg 35a9 ...` (MD_TH_STR_H_B, sensitivity) and `camreg 35a6 ...`
+(MD_BLOCK_NUM_TH_B, trigger block count) buttons - press one and watch which
+grid cells light up as you move a target, then read the effect straight off the
+image. This works because preview arms the HM0360 MD engine to run *concurrently*
+with the main-camera stream (`hm0360_md_prepare(true, interval)`); normally MD
+only runs on the sleep path, so the grid reads empty during an ordinary awake
+capture. See `_Tools/md_sweep.py` for the headless (no-preview) register sweep,
+and `doc/Motion_detection_presets.md` for the parameter map.
+
+Caveat: the grid comes from the HM0360 (its own FOV); on colour builds the
+preview image is the RP3/IMX708 (a different FOV), so the overlay is a spatial
+guide, not a pixel-aligned mask. On HM0360 (night) builds the two align.
 
 ## Bench session recipe
 
@@ -92,14 +120,18 @@ Notes:
 ## Files changed (this branch)
 
 * `EPII_CM55M_APP_S/app/ww_projects/ww500_md/preview.c` / `.h` - new: frame
-  emission (chunked base64, no frame-sized buffer) and mode state.
+  emission (chunked base64, no frame-sized buffer) and mode state. The MD
+  overlay adds: arm the HM0360 MD engine on the first previewed frame
+  (`hm0360_md_prepare(true, OP_PARAMETER_MD_INTERVAL)`) and append
+  `"md_blocks"` + the 32-byte `"md"` grid to each frame line.
 * `EPII_CM55M_APP_S/app/ww_projects/ww500_md/image_task.c` - hook in
   `APP_MSG_IMAGETASK_FRAME_READY`: runs the WB correction in the skip-save
   path when previewing, then `preview_sendFrame()`; `preview 1` joins the
   skip-file-save condition.
 * `EPII_CM55M_APP_S/app/ww_projects/ww500_md/CLI-commands.c` - the `preview`
   command.
-* `_Tools/live_view.py` - new: PC viewer + tuning console.
+* `_Tools/live_view.py` - PC viewer + tuning console; MD motion-grid overlay +
+  MD-tuning quick commands; default port COM13.
 
 Build as usual (`_Tools/build_ww500.sh`, or CI). Works for both camera
 variants; on HM0360 builds the WB correction is simply not compiled in.

--- a/_Tools/live_view.py
+++ b/_Tools/live_view.py
@@ -21,9 +21,15 @@ cycle the device, or wave at the lens if MD is armed), then immediately types
 the keep-awake (the device DPDs ~4 s after an idle cold boot), turns preview
 on and starts a capture burst - every step echo-verified with retries.
 
+When the firmware includes the MD grid in each frame ("md"/"md_blocks" fields,
+preview.c), a translucent 16x16 motion heatmap is drawn over the live image and
+the moving-block count shown in the status panel - toggle with "MD motion
+overlay". Tune MD live with the sidebar buttons (camreg 35a9/35a6 ...) or the
+command box and watch the grid react.
+
 Usage:
-    py live_view.py                    # defaults: COM14, 921600
-    py live_view.py --port COM13
+    py live_view.py                    # defaults: COM13 (Himax), 921600
+    py live_view.py --port COM14
 
 NOTES
  - Close TeraTerm first: Windows COM ports are exclusive.
@@ -52,7 +58,7 @@ from datetime import datetime
 import serial
 import tkinter as tk
 from tkinter import scrolledtext
-from PIL import Image, ImageTk
+from PIL import Image, ImageTk, ImageDraw
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
 
@@ -187,8 +193,16 @@ class SerialWorker(threading.Thread):
                     if count <= 3 or count % 20 == 0:
                         self.log_q.put(f"[frame] #{count} {len(jpeg)} bytes")
                     self._confirm_frame()
+                    # Optional HM0360 motion grid (firmware preview.c): 32 bytes
+                    # as hex = 16x16 bitmap; md_blocks = moving-block count.
+                    md_hex = data.get("md")
+                    try:
+                        md_bytes = bytes.fromhex(md_hex) if md_hex else None
+                    except ValueError:
+                        md_bytes = None
                     self.frame_q.put((data.get("count", 0),
-                                      data.get("resolution", [0, 0]), jpeg))
+                                      data.get("resolution", [0, 0]), jpeg,
+                                      md_bytes, data.get("md_blocks")))
                     # frame boundary = the quiet window: send any pending step
                     self._pump_seq(force=True)
                     return
@@ -267,6 +281,8 @@ class Viewer:
         self.last_rearm = time.monotonic()
         self.frame_times = deque(maxlen=10)
         self.photo = None  # keep a reference or tkinter drops the image
+        self.show_md = tk.BooleanVar(value=True)   # overlay the HM0360 motion grid
+        self.last_md_blocks = None
 
         root.title(f"WW500 Live View - {worker.ser.port} @ {worker.ser.baudrate}")
 
@@ -289,7 +305,9 @@ class Viewer:
 
         tk.Button(side, text="Start stream", command=self.start_stream).pack(fill=tk.X)
         tk.Button(side, text="Stop stream", command=self.stop_stream).pack(fill=tk.X, pady=(4, 0))
-        tk.Button(side, text="Save frame", command=self.save_frame).pack(fill=tk.X, pady=(4, 12))
+        tk.Button(side, text="Save frame", command=self.save_frame).pack(fill=tk.X, pady=(4, 4))
+        tk.Checkbutton(side, text="MD motion overlay", variable=self.show_md,
+                       anchor="w").pack(fill=tk.X, pady=(0, 12))
 
         tk.Label(side, text="Command:").pack(anchor="w")
         self.cmd_entry = tk.Entry(side, width=28, font=("Consolas", 10))
@@ -300,6 +318,14 @@ class Viewer:
         tk.Label(side, text="Quick commands:").pack(anchor="w", pady=(12, 0))
         for cmd in ("getop 27", "setop 27 286", "setop 28 326",
                     "vcm 512", "status", "setop 8 1000"):
+            tk.Button(side, text=cmd, font=("Consolas", 9),
+                      command=lambda c=cmd: self.worker.send(c)).pack(fill=tk.X, pady=1)
+
+        # MD tuning: write HM0360 registers live and watch the overlay change.
+        # (camreg <addr> <val>, hex; 35a9=MD_TH_STR_H_B, 35a6=MD_BLOCK_NUM_TH_B)
+        tk.Label(side, text="MD tuning (hex):").pack(anchor="w", pady=(12, 0))
+        for cmd in ("camreg 35a9 08", "camreg 35a9 20", "camreg 35a9 30",
+                    "camreg 35a6 01", "camreg 35a6 04"):
             tk.Button(side, text=cmd, font=("Consolas", 9),
                       command=lambda c=cmd: self.worker.send(c)).pack(fill=tk.X, pady=1)
 
@@ -315,12 +341,15 @@ class Viewer:
 
     def _set_status(self, info):
         if info is None:
-            self.status.config(text="frames    -\nsize      -\nfps       -\ndropped   0")
+            self.status.config(text="frames    -\nsize      -\nfps       -\n"
+                                    "MD blocks -\ndropped   0")
             return
         count, res, kbytes, fps = info
+        md = "-" if self.last_md_blocks is None else str(self.last_md_blocks)
         self.status.config(text=(f"frames    {count}\n"
                                  f"size      {kbytes:.1f} KB  {res[0]}x{res[1]}\n"
                                  f"fps       {fps:.2f}\n"
+                                 f"MD blocks {md}\n"
                                  f"dropped   {self.worker.dropped}"))
 
     def start_stream(self):
@@ -357,8 +386,9 @@ class Viewer:
         self.log.see(tk.END)
         self.log.config(state=tk.DISABLED)
 
-    def _show_frame(self, count, res, jpeg):
+    def _show_frame(self, count, res, jpeg, md_bytes=None, md_blocks=None):
         self.last_jpeg = jpeg
+        self.last_md_blocks = md_blocks
         now = time.monotonic()
         self.frame_times.append(now)
         fps = 0.0
@@ -375,9 +405,33 @@ class Viewer:
             return
         if img.width > DISPLAY_MAX[0] or img.height > DISPLAY_MAX[1]:
             img.thumbnail(DISPLAY_MAX)
+        if self.show_md.get() and md_bytes is not None and len(md_bytes) == 32:
+            img = self._overlay_md(img, md_bytes)
         self.photo = ImageTk.PhotoImage(img)
         self.image_label.config(image=self.photo, text="", width=img.width, height=img.height)
         self._set_status((count, res, len(jpeg) / 1024.0, fps))
+
+    @staticmethod
+    def _overlay_md(img, md_bytes):
+        """Draw the HM0360 16x16 motion grid as a translucent red heatmap.
+
+        Blocks are row-major: block = row*16 + col; within the 32-byte table
+        block b lives in byte b>>3, bit b&7 (matches hm0360_md_printGrid). The
+        HM0360 FOV is not pixel-aligned with the colour main camera, so treat
+        the overlay as a spatial guide, not a precise mask.
+        """
+        base = img.convert("RGBA")
+        overlay = Image.new("RGBA", base.size, (0, 0, 0, 0))
+        draw = ImageDraw.Draw(overlay)
+        cw = base.width / 16.0
+        ch = base.height / 16.0
+        for block in range(256):
+            if md_bytes[block >> 3] & (1 << (block & 7)):
+                col, row = block % 16, block // 16
+                x0, y0 = col * cw, row * ch
+                draw.rectangle([x0, y0, x0 + cw, y0 + ch],
+                               fill=(255, 40, 40, 90), outline=(255, 80, 80, 170))
+        return Image.alpha_composite(base, overlay).convert("RGB")
 
     def poll(self):
         try:
@@ -419,7 +473,9 @@ class Viewer:
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--port", default="COM14")
+    # The preview stream comes from the Himax HX6538 console = COM13 @ 921600
+    # (COM14 @ 115200 is the nRF52 BLE co-processor, no preview there).
+    ap.add_argument("--port", default="COM13")
     ap.add_argument("--baud", type=int, default=921600)
     args = ap.parse_args()
 

--- a/_Tools/live_view.py
+++ b/_Tools/live_view.py
@@ -191,7 +191,9 @@ class SerialWorker(threading.Thread):
                     self.last_frame_ts = time.monotonic()
                     count = data.get("count", 0)
                     if count <= 3 or count % 20 == 0:
-                        self.log_q.put(f"[frame] #{count} {len(jpeg)} bytes")
+                        _mdb = data.get("md_blocks")
+                        self.log_q.put(f"[frame] #{count} {len(jpeg)} bytes"
+                                       + (f" MD_blocks={_mdb}" if _mdb is not None else " (no MD field)"))
                     self._confirm_frame()
                     # Optional HM0360 motion grid (firmware preview.c): 32 bytes
                     # as hex = 16x16 bitmap; md_blocks = moving-block count.

--- a/_Tools/md_sweep.py
+++ b/_Tools/md_sweep.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Motion-detection register-sweep harness for the WW500 (HM0360 MD engine).
+
+Characterises MD parameters on the bench over the console UART: for each register
+value it writes the register, cues the physical stimulus, reads the motion-block
+count, and logs a CSV row. This is Phase 1 of the motion-preset roadmap
+(doc/Motion_detection_presets.md).
+
+Two register transports (--via):
+  camreg (DEFAULT) - uses the stock `camreg <addr> [<val>]` command that already
+      ships in current firmware, so it runs on the device AS FLASHED, no reflash.
+      Reads/writes go straight to the HM0360; the motion-block count is derived
+      host-side by popcounting the 32 MD_ROI_OUT registers (0x20A1..0x20C0).
+  md - uses the `md read/write/grid/dump` instrumentation from
+      feat/md-instrumentation (single-round-trip grid read, tidier) once flashed.
+
+Prerequisite (a human/hardware step this tool can't do for you):
+  The device must be AWAKE - it sleeps in DPD and wakes on motion/RTC/BLE, not
+  UART. Power-cycle it (or wave at the lens if MD is armed), then this tool's
+  --keep-awake pushes OP 8 (interval-before-DPD) out for the run. Running
+  live_view.py first, or any recent command, also holds it up.
+
+Examples:
+  python md_sweep.py --selftest                       # validate parsers, no device
+  python md_sweep.py --dump --keep-awake              # snapshot MD registers (camreg)
+  python md_sweep.py --sweep 35a6 1 16 1 --csv bn.csv # sweep MD_BLOCK_NUM_TH_B 1..16
+  python md_sweep.py --preset 4                        # apply the P4 (Micro) bundle
+  python md_sweep.py --sweep 209d 0x11 0x55 0x11 --auto 3   # unattended, 3s/step
+  python md_sweep.py --dump --via md                  # once feat/md-instrumentation flashed
+
+CSV columns: ts, addr, value, blocks, note
+"""
+
+import argparse
+import csv
+import re
+import sys
+import time
+
+# Context-B MD registers (the WW500 MD path) + the shared ones. See hm0360_regs.h.
+REG = {
+    "MD_TH_STR_L_B": 0x35AA, "MD_TH_STR_H_B": 0x35A9,
+    "MD_BLOCK_NUM_TH_B": 0x35A6, "MD_LATENCY_TH": 0x209D,
+    "MD_IIR_PARAM": 0x209A, "ROI_V_B": 0x35A7, "ROI_H_B": 0x35A8,
+}
+
+# Registers printed by --dump, in a readable order (name, addr). Mirrors the
+# `md dump` instrumentation but works over camreg on stock firmware.
+DUMP_REGS = [
+    ("MD_CTRL_B (ctx-B enable)", 0x35A5), ("MD_CTRL (main)", 0x2080),
+    ("MD_TH_STR_H_B", 0x35A9), ("MD_TH_STR_L_B", 0x35AA),
+    ("MD_BLOCK_NUM_TH_B", 0x35A6), ("MD_BLOCK_NUM_TH (main)", 0x209B),
+    ("MD_LATENCY (main)", 0x209C), ("MD_LATENCY_TH", 0x209D),
+    ("MD_IIR_PARAM", 0x209A), ("MD_LIGHT_COEF", 0x2099),
+    ("ROI_V_B", 0x35A7), ("ROI_H_B", 0x35A8),
+    ("INT_INDIC (MD_INT=0x08)", 0x2064),
+]
+
+# Starting-hypothesis preset bundles (doc/Motion_detection_presets.md §3). These are
+# to be REPLACED by the values this sweep measures - they are a bench start point.
+# (addr, value) pairs written in order; Delta-t is set separately via OP 11.
+PRESETS = {
+    1: ("High-Noise/Medium", [(0x35AA, 0x28), (0x35A9, 0x28), (0x35A6, 0x0C),
+                              (0x209D, 0x55), (0x209A, 0xF0)]),
+    2: ("Macro/Ultra-slow",  [(0x35AA, 0x18), (0x35A9, 0x18), (0x35A6, 0x01),
+                              (0x209D, 0x11), (0x209A, 0x00)]),
+    3: ("High-Velocity",     [(0x35AA, 0x20), (0x35A9, 0x20), (0x35A6, 0x03),
+                              (0x209D, 0x00), (0x209A, 0x00)]),
+    4: ("Micro/Small",       [(0x35AA, 0x10), (0x35A9, 0x10), (0x35A6, 0x01),
+                              (0x209D, 0x22), (0x209A, 0x80)]),
+}
+
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+# feat/md-instrumentation `md read/write/grid` output (needs that firmware flashed)
+RE_READ = re.compile(r"reg 0x([0-9a-fA-F]{4}) = 0x([0-9a-fA-F]{2})")
+RE_WRITE = re.compile(r"reg 0x([0-9a-fA-F]{4}) <- 0x([0-9a-fA-F]{2}) \(now 0x([0-9a-fA-F]{2})\)")
+RE_GRID = re.compile(r"MD motion in (\d+) blocks")
+# Stock `camreg` output (already in shipping firmware - the default transport).
+# read:  "Camera reg 0x209b = 0x04"     write echoes the same "= 0x.." form.
+RE_CAMREG = re.compile(r"Camera reg 0x([0-9a-fA-F]{4}) = 0x([0-9a-fA-F]{2})")
+
+# HM0360 motion-detection readout region: 32 registers (0x20A1..0x20C0) hold the
+# 16x16 = 256-bit motion bitmap (see hm0360_regs.h, MD_ROI_OUT_0 + ROIOUTENTRIES).
+# Popcount across all 32 bytes == number of blocks currently flagged as motion,
+# i.e. the same figure the `md grid` instrumentation prints - computed host-side
+# so it works on stock firmware via camreg.
+MD_ROI_OUT_BASE = 0x20A1
+MD_ROI_OUT_COUNT = 32
+INT_INDIC = 0x2064   # bit MD_INT (0x08) set when the MD engine has fired
+INT_CLEAR = 0x2065   # write MD_INT (0x08) to clear a stale MD-fired latch
+MD_INT_BIT = 0x08
+
+
+def parse_read(text):
+    m = RE_READ.search(text)
+    return int(m.group(2), 16) if m else None
+
+
+def parse_write_readback(text):
+    m = RE_WRITE.search(text)
+    return int(m.group(3), 16) if m else None
+
+
+def parse_grid_count(text):
+    m = RE_GRID.search(text)
+    return int(m.group(1)) if m else None
+
+
+def parse_camreg(text):
+    m = RE_CAMREG.search(text)
+    return int(m.group(2), 16) if m else None
+
+
+class Device:
+    """Thin console-UART client (mirrors _Tools/ww_serial.py send/read idioms).
+
+    Two transports for the same MD register operations:
+      via="camreg" (default) - uses the stock `camreg` command that ships in
+          current firmware. Register reads/writes go straight to the HM0360;
+          the motion-block count is derived host-side by popcounting the 32
+          MD_ROI_OUT registers. Works TODAY, no reflash.
+      via="md" - uses the `md read/write/grid` instrumentation from
+          feat/md-instrumentation (tidier, single-round-trip grid read) once
+          that firmware is flashed.
+    """
+
+    def __init__(self, port=None, baud=921600, char_delay=0.03, quiet=0.8, timeout=6.0,
+                 via="camreg", serial_obj=None):
+        import serial
+        # serial_obj lets open_pinned() hand us an already-open, awake port.
+        self.port = serial_obj if serial_obj is not None else serial.Serial(port, baud, timeout=0.05)
+        self.char_delay, self.quiet, self.timeout = char_delay, quiet, timeout
+        self.via = via
+
+    def _send(self, cmd):
+        data = (cmd + "\r\n").encode("ascii", "replace")
+        for i in range(len(data)):        # 1-char UART buffer: send slowly
+            self.port.write(data[i:i + 1]); self.port.flush(); time.sleep(self.char_delay)
+
+    def cmd(self, cmd):
+        """Send one command, return the de-ANSI'd response text (until quiet)."""
+        self.port.reset_input_buffer()
+        self._send(cmd)
+        buf, last, deadline = b"", time.monotonic(), time.monotonic() + self.timeout
+        while time.monotonic() < deadline:
+            d = self.port.read(4096)
+            if d:
+                buf += d; last = time.monotonic()
+            elif buf and (time.monotonic() - last) > self.quiet:
+                break
+        return ANSI.sub("", buf.decode("utf-8", "replace"))
+
+    # ---- transport-neutral MD ops (dispatch on self.via) -----------------
+
+    def md_write(self, addr, val):
+        """Write a register, return the read-back value (None if it didn't take)."""
+        if self.via == "camreg":
+            self.cmd(f"camreg {addr:x} {val:x}")   # immediate write + stages it
+            return self.md_read(addr)              # verify by reading back
+        return parse_write_readback(self.cmd(f"md write {addr:x} {val:x}"))
+
+    def md_read(self, addr):
+        if self.via == "camreg":
+            return parse_camreg(self.cmd(f"camreg {addr:x}"))
+        return parse_read(self.cmd(f"md read {addr:x}"))
+
+    def md_grid(self, count=MD_ROI_OUT_COUNT):
+        """Blocks flagged as motion across the first `count` MD_ROI_OUT regs
+        (32 = whole 16x16 grid; a smaller count is a fast partial sample)."""
+        if self.via == "camreg":
+            total = 0
+            for i in range(count):
+                v = self.md_read(MD_ROI_OUT_BASE + i)
+                if v is None:
+                    return None            # sensor unpowered / lost sync
+                total += bin(v).count("1")
+            return total
+        return parse_grid_count(self.cmd("md grid"))
+
+    def md_fired(self):
+        """True if the MD interrupt-indicator shows the engine has triggered."""
+        v = self.md_read(INT_INDIC)
+        return None if v is None else bool(v & 0x08)
+
+    def keep_awake(self, ms=60000):
+        # OP 8 = interval-before-DPD; hold the device up. 16-bit reg, so 60000 ms
+        # is the usable maximum (see live_view.py). Streaming/commands re-arm it.
+        self.cmd(f"setop 8 {ms}")
+
+    def close(self):
+        self.port.close()
+
+
+def _int(s):
+    return int(s, 0)  # accepts 0x.. or decimal
+
+
+def run_selftest():
+    """Validate the parsers against sample device output - no hardware needed."""
+    # feat/md-instrumentation transport
+    assert parse_read("cmd> reg 0x209b = 0x04\ncmd> ") == 0x04
+    assert parse_write_readback("reg 0x35a6 <- 0x08 (now 0x08)") == 0x08
+    assert parse_grid_count("MD motion in 12 blocks (16x16 grid on console)") == 12
+    assert parse_grid_count("no motion here") is None
+    assert parse_read("garbage") is None
+    # stock camreg transport
+    assert parse_camreg("Camera reg 0x209b = 0x04") == 0x04
+    assert parse_camreg("Camera reg 0x20a1 = 0xff") == 0xFF
+    assert parse_camreg("Camera reg 0x0202 = 0x03 (immediate write OK). 1 staged") == 0x03
+    assert parse_camreg("read failed (-1). Is the sensor powered?") is None
+    # host-side grid popcount: 0xff has 8 bits; 32 x 0xff would be 256 blocks (full grid)
+    assert bin(0xFF).count("1") == 8
+    assert sum(bin(0xFF).count("1") for _ in range(MD_ROI_OUT_COUNT)) == 256
+    print("selftest OK: md + camreg read/write/grid parsers verified")
+    return 0
+
+
+ALIVE_MARKERS = (b"OpParam 8", b"Enter 'help'", b"Camera reg", b"cmd>", b"WW500")
+
+
+def open_pinned(port, baud=921600, via="camreg", budget=180.0):
+    """Reopen `port` fresh until the device answers, pin it awake, return a Device.
+
+    The WW500 re-enumerates its USB serial on power-cycle (severing any handle
+    opened beforehand) and DPDs a few seconds after a cold boot. So we reopen a
+    fresh handle each pass and blind-send the keep-awake; whichever pass lands in
+    the post-boot window pins the device up. Returns None if the budget expires.
+    """
+    import serial
+    deadline = time.monotonic() + budget
+    print(f"connecting: reopening {port}@{baud} until awake "
+          f"(power-cycle the device / wave at the lens). budget {budget:.0f}s", file=sys.stderr)
+    passes = 0
+    while time.monotonic() < deadline:
+        passes += 1
+        try:
+            sp = serial.Serial(port, baud, timeout=0.1)
+        except serial.SerialException:
+            time.sleep(0.3)
+            continue
+        try:
+            sp.reset_input_buffer()
+            for ch in b"setop 8 60000\r\n":       # blind keep-awake
+                sp.write(bytes([ch])); sp.flush(); time.sleep(0.03)
+            buf, t = b"", time.monotonic() + 3.0
+            while time.monotonic() < t:
+                d = sp.read(4096)
+                if d:
+                    buf += d; t = time.monotonic() + 1.2
+            if any(m in buf for m in ALIVE_MARKERS):
+                print(f"connected (pass {passes}) - device pinned awake", file=sys.stderr)
+                return Device(serial_obj=sp, via=via)
+        except serial.SerialException:
+            pass
+        try:
+            sp.close()
+        except serial.SerialException:
+            pass
+        time.sleep(0.15)
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    # NB: the Himax HX6538 console is COM13 @ 921600. COM14 @ 115200 is the nRF52
+    # BLE/LoRaWAN co-processor - camreg/md/setop do NOT exist there.
+    ap.add_argument("--port", default="COM13")
+    ap.add_argument("--via", choices=("camreg", "md"), default="camreg",
+                    help="register transport: 'camreg' (stock firmware, default) or "
+                         "'md' (needs feat/md-instrumentation flashed)")
+    ap.add_argument("--selftest", action="store_true", help="validate parsers offline; no device")
+    ap.add_argument("--dump", action="store_true", help="print MD register snapshot (md dump)")
+    ap.add_argument("--preset", type=int, choices=PRESETS.keys(), help="apply a preset bundle")
+    ap.add_argument("--sweep", nargs=4, metavar=("ADDR", "START", "END", "STEP"),
+                    help="sweep a register: hex ADDR, START..END step STEP (0x or dec)")
+    ap.add_argument("--csv", help="append sweep results to this CSV file")
+    ap.add_argument("--auto", type=float, metavar="SECS",
+                    help="unattended: wait SECS between write and grid read instead of prompting")
+    ap.add_argument("--connect-budget", type=float, default=180.0,
+                    help="seconds to spend reopening the port waiting for a cold boot (default 180)")
+    ap.add_argument("--no-pin", action="store_true",
+                    help="skip the reconnect-pin; open the port once (device must already be awake)")
+    ap.add_argument("--full-grid", action="store_true",
+                    help="read all 32 MD_ROI_OUT registers for the block count (slow ~20s); "
+                         "otherwise the sweep records the MD-fired bit (INT_INDIC), 1 read")
+    ap.add_argument("--keep-awake", action="store_true",
+                    help="(kept for compat) the reconnect-pin already holds OP 8 out")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return run_selftest()
+
+    if args.no_pin:
+        try:
+            dev = Device(args.port, via=args.via)
+        except Exception as e:
+            print(f"Cannot open {args.port}: {e}\n"
+                  "Is a terminal holding the port, or the device asleep/unplugged?", file=sys.stderr)
+            return 2
+    else:
+        dev = open_pinned(args.port, via=args.via, budget=args.connect_budget)
+        if dev is None:
+            print("Device never woke within the connect budget. Power-cycle it during the window "
+                  "(and wave at the lens to keep it awake).", file=sys.stderr)
+            return 2
+
+    try:
+        if args.keep_awake or not args.no_pin:
+            dev.keep_awake()
+
+        if args.dump:
+            if args.via == "md":
+                print(dev.cmd("md dump"))
+                return 0
+            print(f"MD register snapshot via camreg ({args.port}):")
+            for name, addr in DUMP_REGS:
+                v = dev.md_read(addr)
+                print(f"  0x{addr:04x}  {name:<26} = "
+                      f"{('0x%02x' % v) if v is not None else '??  (read failed - sensor powered?)'}")
+            blocks = dev.md_grid()
+            print(f"  MD_ROI_OUT popcount (0x20a1..0x20c0) = "
+                  f"{blocks if blocks is not None else '??'} blocks flagged")
+            return 0
+
+        if args.preset:
+            name, bundle = PRESETS[args.preset]
+            print(f"Applying preset {args.preset} ({name}) - HYPOTHESIS values, characterise before trusting:")
+            for addr, val in bundle:
+                got = dev.md_write(addr, val)
+                print(f"  0x{addr:04x} <- 0x{val:02x}  readback {('0x%02x' % got) if got is not None else '??'}")
+            return 0
+
+        if args.sweep:
+            addr = int(args.sweep[0], 16)  # ADDR is always hex (with or without 0x)
+            start, end, step = map(_int, args.sweep[1:])
+            writer = None
+            if args.csv:
+                fh = open(args.csv, "a", newline=""); writer = csv.writer(fh)
+                if fh.tell() == 0:
+                    writer.writerow(["ts", "addr", "value", "fired", "blocks", "note"])
+            print(f"Sweeping 0x{addr:04x} from 0x{start:02x} to 0x{end:02x} step 0x{step:02x}")
+            print("(per step: re-pin awake -> write reg -> clear MD latch -> cue stimulus -> read MD-fired)")
+            v = start
+            while (v <= end) if step > 0 else (v >= end):
+                dev.keep_awake()                     # re-pin so we don't DPD mid-sweep
+                dev.md_write(addr, v)
+                dev.md_write(INT_CLEAR, MD_INT_BIT)  # clear any stale MD-fired latch
+                if args.auto is not None:
+                    time.sleep(args.auto); note = "auto"
+                else:
+                    note = input(f"  0x{addr:04x}=0x{v:02x}: present stimulus, press Enter (or type a note)> ").strip() or "-"
+                fired = dev.md_fired()
+                blocks = dev.md_grid() if args.full_grid else dev.md_grid(8)  # 8 regs = 64 blocks sample
+                gtag = "" if args.full_grid else " (of 64)"
+                ts = time.strftime("%Y-%m-%dT%H:%M:%S")
+                state = "FIRED" if fired else ("quiet" if fired is not None else "??")
+                print(f"    -> MD {state}" + (f", {blocks} blocks{gtag}" if blocks is not None else ""))
+                if writer:
+                    writer.writerow([ts, f"0x{addr:04x}", f"0x{v:02x}",
+                                     "" if fired is None else int(fired),
+                                     "" if blocks is None else blocks, note])
+                v += step
+            if args.csv:
+                fh.close(); print(f"appended to {args.csv}")
+            return 0
+
+        ap.print_help()
+        return 0
+    finally:
+        dev.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Stacks the motion-detection instrumentation work on top of `feat/uart-live-preview`. Eight commits in three groups; the two JPEG/hi-res commits are the shared base that #144 builds on.

> **Stacked PR** — review order: #141 → #142 → #140 → **#143** → #144. This diff shows only this branch's increment over `feat/uart-live-preview`.

### Software-JPEG + hi-res capture pipeline (shared base)
- **`f49c2286` streaming (strip) API for the software JPEG encoder** — lets the SW JPEG encoder emit strip-by-strip so no frame-sized buffer is needed.
- **`4dbb5f9f` 1280×960 single-JPEG capture on the CPU pipeline (op32)** — `hires.c`/`demosaic.c` + `sw_jpeg`/`cisdp_sensor` changes for a full-res single-JPEG path. (Completed and hardware-proven in #144.)

### Motion-detection instrumentation
- **`653ed6cb` MD preset blueprint** (`doc/Motion_detection_presets.md`) — HM0360 register map, 4 real-world presets, roadmap, QA matrix.
- **`c4269a25` Phase-0 MD register instrumentation** — `md read/write/grid/dump` CLI subcommands + `hm0360_md_readReg/writeReg/dumpConfig` for characterising MD registers on the bench.
- **`50f1ebbe` live HM0360 motion overlay in preview + `camreg` sweep harness** — preview arms the HM0360 MD engine concurrently with the stream (`hm0360_md_prepare(true,…)`) and emits the 16×16 motion grid (`md`/`md_blocks`) in each frame; `live_view.py` overlays it as a heatmap and gains MD-tuning quick commands; `_Tools/md_sweep.py` drives MD register read/write over the stock `camreg` command (no reflash) for headless sweeps.

### Added since first review
- **`43b1006c` op33 global-motion rejection** — new `OP_PARAMETER_MD_BLOCK_NUM_MAX`: on an MD wake, read the triggering 16×16 bitmap (held in `MD_ROI_OUT` until the deferred interrupt clear) and **skip the capture when more blocks moved than the limit** — a whole-scene shift (camera knock/pan, lighting flip) lights most of the grid; an animal lights a small cluster. 0 = disabled; rejections are reported to the BLE master.
- **`13bda489` FatFS `save_configuration` stack-overflow fix** (cherry-pick) — **required**: op33 grows the op table to 34 entries; without this fix every config save overflows the FatFS task stack (~3 KB local on a ~2.8 KB stack) — this is the UsageFault that crashed a field device during stop-monitoring on 16 Jul.
- **`f449a235`** — `live_view.py` logs MD-field presence per frame (bench diagnostics).

## Verification
- **MD register read/write/restore proven on real hardware** via `camreg` (Himax console = COM13 @ 921600) — full baseline MD config captured; write→readback→restore round-trip confirmed.
- **Key hardware finding:** the HM0360 MD engine only runs on the sleep path — a register poll while the SoC is pinned awake reads 0 at every threshold. The overlay works around this by arming MD concurrently during preview.
- The live overlay + op33 are **code-complete but not yet flashed/hardware-tested**; build from #144's branch (`feat/hires-capture-fixes`) to test everything at once.

## Review-bot findings
The Gemini findings on this PR (strict `md read/write` hex parsing, hi-res-aware preview resolution, demosaic pattern mask, raw-buffer alignment tripwire) are **fixed in `959c1baf` on the child branch** (#144) — this branch was already stacked under #144 when the review landed, and fixing here would have forced another rebase of the child. See #144's update section for the taken/adapted/skipped breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
