### PR TITLE
fix(ww500_md): iOS transfers die at ~30s — extend session inactivity 5s→15s

### DIFF
--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/WW500_ble_file_transfer.md
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/WW500_ble_file_transfer.md
@@ -85,7 +85,7 @@ While streaming, the Android BLE stack renegotiates connection parameters at
 certain points; the link stalls ~950 ms. Our "I2C master did not read our
 message" watchdog was 1000 ms — right on the edge — and a firing watchdog
 tears the session down. 4 s rides the renegotiation out while staying well
-under the 5 s session inactivity hold and the app's 15 s abort.
+under the 15 s session inactivity hold and the app's 15 s abort.
 
 **What did NOT work:** the app originally re-requested Android's HIGH
 connection priority every 20 s to keep the fast interval. That renegotiation
@@ -97,8 +97,19 @@ reliability. This is why "fast bursts, slower sustained".
 
 ### 5. Session inactivity hold
 
-A transfer session holds off DPD (5 s inactivity extension at FILE_START,
+A transfer session holds off DPD (15 s inactivity extension at FILE_START,
 restored at close/abort) so the device does not sleep between packets.
+
+The hold was originally 5 s, which iOS defeated (bench 19 Jul 2026, app
+0.0.60 with write-with-response): ~28–30 s into a large transfer iOS
+renegotiates the connection interval and CoreBluetooth stalls the in-flight
+write for >5 s. The device saw 5 s of silence, logged
+`WARNING: incomplete file transfer — closing before DPD`, and slept at the
+exact moment the phone recovered — LARGE.BIN died at packet 96/2125, while
+the same transfer completes on Android (its stalls are sub-second). 15 s
+matches the app's own silence budget: both ends now tolerate the same
+worst-case gap, so a renegotiation stall is a pause, not a death. An
+abandoned session costs one delayed DPD entry, nothing more.
 
 ### 6. Slot-label robustness (`camera_switch.c`)
 

--- a/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
+++ b/EPII_CM55M_APP_S/app/ww_projects/ww500_md/if_task.c
@@ -253,7 +253,17 @@ static uint8_t          fileRxPacketNum;
 // mid-transfer (ftx err 7). Saved/restored around each session; if a session
 // dies without a CLOSE (e.g. BLE dropped), the extended period simply delays
 // the next DPD entry once — the period resets on wake from DPD.
-#define FILERX_SESSION_INACTIVITY_MS 5000
+//
+// 15000 not 5000: iOS renegotiates the connection interval ~28-30 s into a
+// transfer, and CoreBluetooth can stall the in-flight write for >5 s (bench
+// 19 Jul 2026: LARGE.BIN died at packet 96/2125 — the HX hit "Inactive for
+// 5000ms", aborted the session and entered DPD at the exact moment the phone
+// was about to resume; Android stalls are sub-second and never exposed this).
+// The app tolerates 15 s of device silence before aborting, so the device
+// must extend the same tolerance — a renegotiation stall then becomes a
+// pause, not a death. Cost of the larger value: one delayed DPD entry after
+// an abandoned session, nothing more.
+#define FILERX_SESSION_INACTIVITY_MS 15000
 static uint32_t savedInactivityPeriod;
 static bool     inactivityExtended = false;
 


### PR DESCRIPTION
## Summary

One-line firmware fix for the iOS large-transfer failure: `FILERX_SESSION_INACTIVITY_MS` **5000 → 15000** in `if_task.c` (plus the matching doc update in `WW500_ble_file_transfer.md`). Stacked on `feat/ble-fast-transfer` (#142) so that branch stays exactly as Charles is reviewing it — merge this after (or fold it in with his blessing).

## The bug, with bench evidence (19 Jul 2026, dual-console capture)

App 0.0.60 (iOS, write-with-response per wildlifeai/ww-mobile-app#213) → WW500 C02, BLE 0.30.47, LARGE.BIN (512 KB, 2125 packets):

| Time | Event |
|---|---|
| t+0s | FILE_START → HX wakes from DPD, opens file, `ftx ack 0` |
| t+0→28s | 96 packets delivered in order, 11–18 ms/packet at the HX, cumulative acks streaming (`ftx ack 4 … 93`) |
| ~t+28s | iOS renegotiates the connection interval (its version of the ~25 s Android decay); CoreBluetooth stalls the in-flight write **>5 s** |
| t+33s | HX: `Inactive for 5000ms` → `WARNING: incomplete file transfer — closing before DPD` → device **sleeps mid-session** |
| t+58s | nRF: `fileTx: session timeout — resetting` |

The device gave up at the precise moment the phone was about to resume. Android never exposes this because its renegotiation stalls are sub-second. Reproducible every run at packet ~96 (~4.5%) — this is the same death previously misattributed to dropped writes ("dies at ~6%"): #213 genuinely fixed the drops (96/96 packets delivered, in order), and this stall was the second layer underneath.

## Why 15 s

The app aborts after 15 s of device silence; the device was aborting after only 5 s of app silence. This aligns both ends' patience so a renegotiation stall becomes a pause, not a death. Cost: an abandoned session delays one DPD entry by 10 extra seconds, nothing more.

## Also observed (separate, app-side)

After the device slept, the app's session retry never fired — it sat stalled until the local disconnect. Worth a look in `runFileTransferPipeline.ts` retry classification, but moot for this failure once the device tolerates the stall.

## Testing ask

Rebuild + iOS LARGE.BIN retest is the acceptance test: expect steady (slow) progress through the ~30 s mark to completion.
