### PR TITLE
ci: manual dispatch honours environment input for builds

### DIFF
--- a/.github/workflows/build_and_upload_firmware.yml
+++ b/.github/workflows/build_and_upload_firmware.yml
@@ -35,7 +35,7 @@ on:
           - build
           - prebuilt
       environment:
-        description: 'Target Supabase database (prebuilt only - builds from a branch always go to dev; merge to main for production)'
+        description: 'Target Supabase database (production is gated by the GitHub environment protection rules)'
         required: true
         default: 'dev'
         type: choice
@@ -61,13 +61,11 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             SOURCE="${{ inputs.source }}"
-            if [ "$SOURCE" = "prebuilt" ]; then
-              # Capability 3: developer uploads the committed image to either database
-              ENVIRONMENT="${{ inputs.environment }}"
-            else
-              # Capability 4: developer builds from any branch - dev database only
-              ENVIRONMENT="dev"
-            fi
+            # Manual dispatch honours the environment input for both sources
+            # (build and prebuilt). Production is guarded by the GitHub
+            # environment's protection rules (required reviewers / allowed
+            # branches), not by this file.
+            ENVIRONMENT="${{ inputs.environment }}"
           else
             # Push events: build from source; main -> production, dev -> dev
             SOURCE="build"


### PR DESCRIPTION
## Summary
Cherry-picked from `ci/hires-production-upload` (which was stacked on the unmerged hi-res chain; this is the branch's one unique commit, rebased clean onto dev).

Manual `workflow_dispatch` of `build_and_upload_firmware.yml` previously forced `environment=dev` whenever `source=build` — a from-branch build could never target production even deliberately. The environment input is now honoured for **both** sources, with production access controlled where it belongs: the GitHub **environment protection rules** (required reviewers / allowed branches), not workflow logic. Push-event behaviour is unchanged (main → production, dev → dev).

## Why now
Once the hi-res PR stack (#144→#143→#140→#142→#141) merges to dev, this lets a verified build be dispatched to the production database without waiting for a dev→main merge, while still requiring the environment gate's approval.

## Housekeeping
`ci/hires-production-upload` on origin is superseded by this PR and can be deleted after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)