### PR TITLE
docs: agent guide (AGENTS.md), Claude bridge and firmware agent skill

### DIFF
--- a/.agents/skills/SKILL.md
+++ b/.agents/skills/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: ww-firmware-agent
+description: >
+  Essential workflow, repository awareness and guardrails for any agent working on the
+  Wildlife Watcher WW500 firmware (Himax WiseEye2 / Seeed Grove Vision AI V2). Read and
+  follow this skill before changing code, building, flashing hardware, or writing
+  documentation in this repository.
+---
+
+# Wildlife Watcher Firmware Agent
+
+This repository holds the AI-processor (HX6538) firmware. The production application is
+`EPII_CM55M_APP_S/app/ww_projects/ww500_md`, built in **two camera variants** that live in
+the device's A/B flash slots: `cis_imx708` (RP3 day/colour) and `cis_hm0360` (HM0360
+night/IR). The BLE relay processor lives in the separate `ww-hardware` repo; the app,
+website and backend consume this firmware's EXIF fields, op-parameters and BLE commands.
+
+> **Canonical documentation** — consult before assuming:
+>
+> * `_Documentation/building_firmware.md` — toolchain (Arm GNU 14.3.rel1), two-variant build, image generation
+> * `_Documentation/firmware_update_and_recovery.md` — update paths, XMODEM recovery, slot model
+> * `_Documentation/Operational_Parameters.md` + `MANIFEST/config_file.md` — op-parameter meanings and defaults
+> * `_Documentation/ble_commands.md` — console/BLE command surface (the app speaks `AI <cmd>`)
+> * `EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/` — subsystem notes (slot_selector.md, FatFS behaviour, …)
+> * `REVIEW_PR<N>.md` at a branch tip — offline copy of that PR's description
+> * `_Documentation/development reports/` — **how the code got this way**; check the relevant
+>   thread before re-deriving or re-litigating a past decision
+
+# 1. Development conversations and documentation
+
+**Docs are the record; GitHub issues are the tracker** (project board:
+`https://github.com/orgs/wildlifeai/projects/3`, auto-add is enabled for this repo).
+
+* Substantive investigation, review exchange or design discussion goes in a dated thread
+  under `_Documentation/development reports/YYYY-MM_topic/` — see the README there. Never
+  leave that material only in a chat transcript, email or PR comment.
+* Every thread README keeps **Status / Outcome / Open items** current. Open items are
+  GitHub issue links, nothing else — a document must never be the only place an open item
+  lives. File issues with the `review-finding` template.
+* When something is agreed, update the affected topic doc (the "what") and the thread's
+  Outcome (the "why") in the same change. A thread closes only when its checklist is
+  ticked.
+* Keep hardware evidence: bench/serial logs supporting a claim belong in the thread's
+  `logs/` folder, referenced from the write-up.
+
+# 2. Git guardrails
+
+* **Never rebase or force-push** the stacked feature branches — the stack breaks and
+  reviewers' diff bases move.
+* Review edits go on `review/<name>-<topic>` branches, not directly on shared feature
+  branches; they are cherry-picked across after discussion.
+* Ask the maintainer before pushing to any shared branch. Commit messages use
+  conventional prefixes (`feat:`, `fix:`, `docs:`, `ci:`).
+* **Never commit build churn**: `prebuilt_libs/**/*.a` deltas, `we2_image_gen_local*/`
+  outputs, stray `NUL` files, `obj_*` trees. Check `git status` before staging.
+
+# 3. Build and flash invariants
+
+* Toolchain is pinned: **Arm GNU 14.3.rel1**. Build under WSL/Linux;
+  `make clean` between camera variants is **mandatory** (objects don't encode the `-D`
+  flags). Both variants must build — a change that compiles for one only is broken.
+* Image generation uses `we2_image_gen_local_dpd` with the **RC24M** profile; both
+  variants emit the same `output.img` path — rename between runs.
+* SD-card firmware files: **8.3 filenames** in `/MANIFEST` (FatFS has no LFN support).
+* Device consoles: two USB serial ports — the Himax console is the one printing clean
+  text at **921600 baud**; the other is the BLE debug UART.
+
+# 4. Hardware behaviour that will trap you
+
+Verified on the bench (details + serial evidence in
+`_Documentation/development reports/2026-07_pr141-review-cgp/`):
+
+* **Slot labels self-heal at first boot** — flashing clears the target slot's label to
+  `unknown`; each image labels its own slot on every boot. `slots` showing `unknown` for
+  a never-booted slot is designed behaviour. Never gate the labelling call on cold boot.
+* **Deliberate reboots are deferred watchdog resets** (`reset`, `switchslot`,
+  auto-switch): they execute at the next sleep and the following boot classifies as a
+  **cold** boot (PMU wakeup registers read zero).
+* **Cold-boot IMX708 first captures are flaky** (instant retries all fail); DPD-wake
+  captures are reliable — prefer wake-path captures for bench validation.
+* **Console sessions**: an untouched boot sleeps after ~1 s; most commands hold the
+  device awake ~60 s; the `reset` command deliberately does not.
+* **camreg staged registers** (`RPV3_EX.BIN` etc.) are re-applied after the init tables
+  at every sensor init — they override defaults, persist on SD, and survive DPD.
+
+# 5. Cross-repo contracts
+
+EXIF fields (Model, MakerNote), op-parameter indices/defaults, and BLE command syntax are
+consumed by ww-mobile-app, ww-website and ww-backend, and mirrored in ww-hardware's
+`aiProcessor.h`. Never change one unilaterally: file a `Decide:` issue, agree the
+contract, and land the change with the consumers in view.

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ we2_image_gen_local_dpd/secureboot_tool/**/*.log
 # Track all other subfolders normally (do not ignore their contents)
 # No need to do anything else � they are tracked by default
 
-
 # Python bytecode
 *.pyc
 *.pyo
@@ -79,9 +78,8 @@ __pycache__/
 node_modules/
 
 # Agent and Editor settings
-.agents/
 .cursorrules
 .windsurfrules
-CLAUDE.md
+
 .claude/
 **/claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent guide — Wildlife Watcher WW500 firmware
+
+AI-processor (Himax HX6538 / Seeed Grove Vision AI V2) firmware for the Wildlife Watcher
+WW500 camera. Production app: `EPII_CM55M_APP_S/app/ww_projects/ww500_md`, built in two
+camera variants that occupy the device's A/B flash slots.
+
+**Before changing code, building, flashing or writing docs, read
+[`.agents/skills/SKILL.md`](.agents/skills/SKILL.md)** — workflow, guardrails, and
+bench-verified hardware behaviour. This file is only the quickstart.
+
+## Build (WSL/Linux, toolchain pinned to Arm GNU 14.3.rel1)
+
+```bash
+cd EPII_CM55M_APP_S
+make clean && make -j"$(nproc)" CIS_SUPPORT_INAPP_MODEL=cis_imx708   # RP3 day/colour
+make clean && make -j"$(nproc)" CIS_SUPPORT_INAPP_MODEL=cis_hm0360   # HM0360 night/IR
+```
+
+`make clean` between variants is mandatory; **both variants must build** (CI enforces the
+matrix). Flashable image: `we2_image_gen_local_dpd` with the RC24M profile — full recipe
+in `_Documentation/building_firmware.md`; flashing and recovery in
+`_Documentation/firmware_update_and_recovery.md`.
+
+## Non-negotiables
+
+- Never rebase or force-push the stacked feature branches; review work goes on
+  `review/<name>-<topic>` branches.
+- Ask the maintainer before pushing to any shared branch.
+- Never commit build churn (`prebuilt_libs/**/*.a`, image-generator outputs, `NUL`,
+  `obj_*`).
+- Docs are the record, GitHub issues are the tracker: substantive findings go in
+  `_Documentation/development reports/`, open items become issues (they auto-add to the
+  [project board](https://github.com/orgs/wildlifeai/projects/3)).
+- EXIF fields, op-parameters and BLE commands are cross-repo contracts (app, website,
+  backend, ww-hardware) — never change unilaterally.
+
+## Where things are
+
+| | |
+|---|---|
+| Durable docs | `_Documentation/`, `EPII_CM55M_APP_S/app/ww_projects/ww500_md/doc/` |
+| How the code got this way | `_Documentation/development reports/` |
+| Op parameters | `_Documentation/Operational_Parameters.md`, `MANIFEST/config_file.md` |
+| Console/BLE commands | `_Documentation/ble_commands.md` (`help` on the console lists all) |
+| PR summary at a branch tip | `REVIEW_PR<N>.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
### **User description**
Gives coding agents (and new developers) a self-loading orientation for this repo, matching the `.agents/skills/SKILL.md` convention already used in ww-website and ww-backend.

- **AGENTS.md** (root): quickstart — repo identity, the two-variant build commands and their invariants (`make clean` between variants; both variants must build), five non-negotiables (stacked-branch rules, ask-before-push, no build churn, docs-are-record/issues-are-tracker, cross-repo contracts), and a map of the documentation.
- **CLAUDE.md** (root): one line, `@AGENTS.md` — Claude Code auto-loads the same guide.
- **.agents/skills/SKILL.md**: the deep layer — development-conversation workflow (`_Documentation/development reports/` + issues on the project board), git and build/flash guardrails, bench-verified hardware behaviour (slot-label lifecycle, deferred watchdog resets → cold boot, cold-boot IMX708 capture flakiness vs reliable DPD-wake captures, console session rules, camreg staged registers), and the cross-repo contract list.
- **.gitignore**: stops ignoring the shared `.agents/` folder and `CLAUDE.md` so they can be committed; personal agent/editor configs (`.claude/`, `.cursorrules`, `.windsurfrules`, `**/claude/`) remain ignored.

Docs-only; no firmware changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Documentation


___

### **Description**
- Added `AGENTS.md` for agent quickstart.

- Created `.agents/skills/SKILL.md` for deep-layer guidance.

- Configured `CLAUDE.md` to auto-load the guide.

- Updated `.gitignore` to include agent files.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AGENTS["AGENTS.md"] -- "Quickstart" --> Agent["Coding Agent"]
  SKILL[".agents/skills/SKILL.md"] -- "Deep-layer workflow" --> Agent
  CLAUDE["CLAUDE.md"] -- "Auto-loads" --> AGENTS
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Define firmware development workflow and hardware guardrails</code></dd></summary>
<hr>

.agents/skills/SKILL.md

<ul><li>Defined development workflow and documentation standards.<br> <li> Established git and build/flash guardrails.<br> <li> Documented verified hardware behaviours and cross-repo contracts.</ul>


</details>


  </td>
  <td><a href="https://github.com/wildlifeai/Seeed_Grove_Vision_AI_Module_V2/pull/150/files#diff-c29524bad29189dd5738936f3362c9461771cdaaa87be91ac3a74eb2dde343ea">+91/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Add repository quickstart guide for coding agents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Created repository quickstart guide for coding agents.<br> <li> Outlined build commands and mandatory invariants.<br> <li> Listed non-negotiable development rules and documentation map.</ul>


</details>


  </td>
  <td><a href="https://github.com/wildlifeai/Seeed_Grove_Vision_AI_Module_V2/pull/150/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+45/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CLAUDE.md</strong><dd><code>Configure Claude Code to load agent guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CLAUDE.md

- Linked to `AGENTS.md` to enable auto-loading in Claude Code.


</details>


  </td>
  <td><a href="https://github.com/wildlifeai/Seeed_Grove_Vision_AI_Module_V2/pull/150/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.gitignore</strong><dd><code>Allow agent-related files in version control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.gitignore

- Removed `.agents/` and `CLAUDE.md` from ignored files.


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

